### PR TITLE
add docker, travis and makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/*
+lib/*
+build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: groovy
 
 sudo: required
 
+branches:
+  only:
+    - master
+
 services:
     - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: groovy
+
+sudo: required
+
+services:
+    - docker
+
+before_install:
+    - make build
+    - make run
+
+script:
+    make healthcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:16.04
+
+USER root
+RUN apt-get update -y && \
+    apt-get install -y openjdk-8-jdk && \
+    apt-get install -y curl
+RUN mkdir /usr/share/jenkins && \
+    curl  https://s3.amazonaws.com/edx-testeng-tools/jenkins/jenkins_1.651.3.war \
+         -L -o /usr/share/jenkins/jenkins.war
+EXPOSE 8080
+ENV JENKINS_HOME /var/lib/jenkins
+CMD /usr/bin/java -jar /usr/share/jenkins/jenkins.war --httpPort=8080

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ build:
 run:
 	docker run --name jenkins-1.6 -p 8080:8080 -d jenkins-1.6
 
-healthchecks:
+healthcheck:
 	./healthcheck.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.DEFAULT_GOAL := help
+
+help:
+	@echo ''
+	@echo 'Makefile for '
+	@echo '     make help           show this information'
+	@echo '     make clean          shutdown running container and delete image'
+	@echo '     make build          build a dockerfile for testing the jenkins configuration'
+	@echo '     make run            run the dockerfile in the background'
+	@echo '     make healthcheck    run healthcheck script to test if Jenkins has successfully booted'
+
+clean:
+	docker kill jenkins-1.6
+	docker rm jenkins-1.6
+	docker rmi jenkins-1.6
+
+build:
+	docker build -t jenkins-1.6 .
+
+run:
+	docker run --name jenkins-1.6 -p 8080:8080 -d jenkins-1.6
+
+healthchecks:
+	./healthcheck.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .DEFAULT_GOAL := help
+.PHONY: clean build
 
 help:
 	@echo ''

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+Jenkins Configuration
+---------------------
+
+A collection of groovy scripts for automating the configuration of Jenkins and
+third party plugins
+
+Tools like the Jenkins Job DSL allow you to programmatically create jobs and other
+resources. However, the configuration of Jenkins itself is still a manual process and is error prone.
+These scripts can be used to create a reproducible and testable Jenkins instance, complete with
+plugins installed and ready to use.
+
+## Setup
+
+Working on this repository requires that both Docker and Gradle are installed.
+
+## Testing
+
+Build a Docker image with Jenkins and the scripts from this repo installed
+``
+    make build
+``
+
+Run the image in the background
+``
+    make run
+``
+
+Test that Jenkins has initialized correctly
+``
+    make healthcheck
+``

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ third party plugins
 Tools like the Jenkins Job DSL allow you to programmatically create jobs and other
 resources. However, the configuration of Jenkins itself is still a manual process and is error prone.
 These scripts can be used to create a reproducible and testable Jenkins instance, complete with
-plugins installed and ready to use.
+plugins installed and is ready to use.
 
 ## Setup
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -10,7 +10,9 @@ echo "Wait 30 seconds for Jenkins to boot"
 sleep 30
 
 echo "Curling against the Jenkins server"
-STATUS_CODE=$(curl -sL -w "%{http_code}" localhost:8080 -o /dev/null)
+echo "Should expect a 200 within 15 seconds"
+STATUS_CODE=$(curl -sL -w "%{http_code}" localhost:8080 -o /dev/null \
+    --max-time 15)
 
 if [[ "$STATUS_CODE" == "200" ]]; then
     echo "Jenkins has come up and ready to use"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Run a curl against the Jenkins instance installed in a Dockerfile
+# to do a basic health check
+
+set -e
+set -x
+
+echo "Wait 30 seconds for Jenkins to boot"
+sleep 30
+
+echo "Curling against the Jenkins server"
+STATUS_CODE=$(curl -sL -w "%{http_code}" localhost:8080 -o /dev/null)
+
+if [[ "$STATUS_CODE" == "200" ]]; then
+    echo "Jenkins has come up and ready to use"
+    exit 0
+else
+    echo "Jenkins did not return a correct status code."
+    echo "Returned: $STATUS_CODE"
+    exit 1
+fi


### PR DESCRIPTION
@jzoldak @michaelyoungstrom 
Initial repo set up. This will create a dockerfile containing a very similiar version of Jenkins to the one we have installed on build jenkins. You can run the docker container and curl against the port that Jenkins is running against to make sure that it is functional.