### PR TITLE
adjust dockerfile to create groovy init and jenkins user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,16 @@ RUN mkdir /usr/share/jenkins && \
          -L -o /usr/share/jenkins/jenkins.war
 EXPOSE 8080
 ENV JENKINS_HOME /var/lib/jenkins
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -g ${gid} ${group} \
+    && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+
+RUN mkdir -p $JENKINS_HOME/init.groovy.d
+RUN chown -R ${user}:${group} $JENKINS_HOME
+
 CMD /usr/bin/java -jar /usr/share/jenkins/jenkins.war --httpPort=8080


### PR DESCRIPTION
@jzoldak @michaelyoungstrom 
This was sort of a chicken & egg problem. Jenkins will run the groovy in init.groovy.d on every boot. However, the jenkins war file (on first boot) creates the jenkins user, group and init.groovy.d directory. 