### PR TITLE
use deprecated trusty sudo box

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: groovy
 
 sudo: required
 
+group: deprecated-2017Q2
+
 branches:
   only:
     - master


### PR DESCRIPTION
Temporary fix: travis recently upgraded their sudo-enabled trusty boxes, and it is causing tests to error out. Need to get this working (the deprecated environments will be terminated by september 1), but in the meantime, this should get us testing again while we sort out what the issue was.