### PR TITLE
allow groovy scripts to read yaml configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/*
 
 # ignore pytest artifacts
 .cache/*
+
+# ignore testing variable script
+local_env.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN mkdir -p $JENKINS_HOME/init.groovy.d \
 COPY src/main/groovy/*.groovy $JENKINS_HOME/init.groovy.d/
 COPY plugins $JENKINS_HOME/plugins/
 COPY utils/ $JENKINS_HOME/utils/
+COPY $CONFIG_PATH $JENKINS_HOME/init-configs
 
 RUN chown -R ${user}:${group} $JENKINS_HOME
 

--- a/local_env.sh.sample
+++ b/local_env.sh.sample
@@ -1,0 +1,8 @@
+# Local environnment setup example
+# Copy to a new file (local_env.sh) and fill in the values you wish
+# By default, these variables all default to using the config files found in
+# jenkins-configuration/test_data
+# Run `source local_env.sh` to set up your environment
+
+export CONFIG_PATH='test_data'
+export PLUGIN_CONFIG='test_data/plugins.yml'


### PR DESCRIPTION
Used for testing/development. This will allow you put various yaml config files onto the Docker container so that the groovy init scripts can parse out data for configuring Jenkins.

Note: not sure if this is what we want to do when it comes to running ansible plays. Sensitive data is likely to be passed via ansible to the system and stored in memory, not on the FS.

cc @edx/devops 