### PR TITLE
Estute/basic global script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ cache:
 before_install:
     - make plugins
     - make requirements
+    - cp local_env.sh.sample local_env.sh && source local_env.sh
     - make build
     - make run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ EXPOSE 8080
 ENV JENKINS_HOME /var/lib/jenkins
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
+ARG CONFIG_PATH
+ENV JENKINS_CONFIG_PATH /init-configs
+
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -24,7 +27,7 @@ RUN mkdir -p $JENKINS_HOME/init.groovy.d \
 COPY src/main/groovy/*.groovy $JENKINS_HOME/init.groovy.d/
 COPY plugins $JENKINS_HOME/plugins/
 COPY utils/ $JENKINS_HOME/utils/
-COPY $CONFIG_PATH $JENKINS_HOME/init-configs
+COPY ${CONFIG_PATH} init-configs/
 
 RUN chown -R ${user}:${group} $JENKINS_HOME
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean.ws:
 	./gradlew clean
 
 build:
-	docker build -t $(jenkins_version) .
+	docker build -t $(jenkins_version) --build-arg=CONFIG_PATH=$(CONFIG_PATH) .
 
 run:
 	docker run --name $(jenkins_version) -p 8080:8080 -d $(jenkins_version)

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,12 @@ apply plugin: 'codenarc'
 
 def utilsPath = 'utils'
 def pluginsPath = 'plugins'
+def jenkinsVersion = '1.651'
 
 repositories {
     mavenCentral()
+    jcenter()
+    maven { url 'http://repo.jenkins-ci.org/releases/' }
 }
 
 configurations {
@@ -16,7 +19,11 @@ configurations {
 dependencies {
     libs 'org.apache.ivy:ivy:2.4.0@jar'
     compile 'org.codehaus.groovy:groovy-all:2.1.3'
+    compile 'javax.servlet:servlet-api:2.4'
+    compile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
     testCompile 'org.codehaus.groovy:groovy-all:2.1.3'
+    testCompile 'javax.servlet:servlet-api:2.4'
+    testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
 }
 
 codenarc {
@@ -36,4 +43,8 @@ task libs(type: Copy) {
 clean {
     delete "${utilsPath}"
     delete "${pluginsPath}"
+}
+
+tasks.withType(GroovyCompile) {
+    groovyClasspath += configurations.libs
 }

--- a/codenarc/rules.groovy
+++ b/codenarc/rules.groovy
@@ -8,6 +8,8 @@ ruleset {
 
     ruleset('rulesets/generic.xml')
 
-    ruleset('rulesets/imports.xml') 
+    ruleset('rulesets/imports.xml') {
+        exclude 'NoWildcardImports'
+    }
 
 }

--- a/e2e/test_access.py
+++ b/e2e/test_access.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+import requests
+
+class AccessTestCase(TestCase):
+
+    def setUp(self):
+        self.jenkins_url = 'http://localhost:8080'
+
+    def test_cli_access(self):
+        cli_status_code = requests.get("{}/cli".format(self.jenkins_url)).status_code
+        assert cli_status_code == 404

--- a/src/main/groovy/1addJarsToClasspath.groovy
+++ b/src/main/groovy/1addJarsToClasspath.groovy
@@ -9,6 +9,7 @@
 import org.codehaus.groovy.runtime.DefaultGroovyMethods
 import java.util.regex.Matcher
 import java.util.logging.Logger
+import jenkins.model.*
 
 Logger logger = Logger.getLogger("")
 
@@ -45,7 +46,11 @@ jarPath.eachFile() { file ->
             logger.info("Successfully added ${fileName}")
         }
         catch (Exception e) {
-            logger.info("Unable to load ${fileName}")
+            logger.severe("Unable to load ${fileName}")
+            logger.severe("Cancelling Jenkins start up.")
+            Jenkins jenkins = Jenkins.getInstance()
+            jenkins.doSafeExit(null)
+            System.exit(1)
         }
     }
 }

--- a/src/main/groovy/2checkInstalledPlugins.groovy
+++ b/src/main/groovy/2checkInstalledPlugins.groovy
@@ -1,0 +1,42 @@
+/**
+* verify plugin installations
+*
+* check that each expected plugin is installed and at the expected version
+*
+**/
+
+import java.util.logging.Logger
+import jenkins.*
+import jenkins.model.*
+import hudson.model.*
+@Grapes([
+    @Grab(group='org.yaml', module='snakeyaml', version='1.17')
+])
+import org.yaml.snakeyaml.Yaml
+
+Logger logger = Logger.getLogger("")
+
+logger.info("Loading plugin configuration")
+Yaml yaml = new Yaml()
+String configPath = System.getenv("JENKINS_CONFIG_PATH")
+List expectedPlugins = yaml.load(new File("${configPath}/plugins.yml").text)
+
+Jenkins jenkins = Jenkins.getInstance()
+List installedPlugins = jenkins.getPluginManager().plugins
+
+expectedPlugins.each { expectedPlugin ->
+
+    Boolean isInstalled = installedPlugins.any { installedPlugin ->
+        return installedPlugin.shortName == expectedPlugin.name &&
+        installedPlugin.version == expectedPlugin.version
+    }
+    if (!isInstalled) {
+        logger.severe("Expected plugin ${expectedPlugin.name} @ version ${expectedPlugin.version} not installed!")
+        logger.severe("Cancelling Jenkins start up.")
+        jenkins.doSafeExit(null)
+        System.exit(1)
+    }
+    logger.info("Plugin ${expectedPlugin.name} @ version ${expectedPlugin.version} is installed")
+
+}
+logger.info("All expected plugins are installed correctly")

--- a/src/main/groovy/3shutdownCLI.groovy
+++ b/src/main/groovy/3shutdownCLI.groovy
@@ -1,0 +1,56 @@
+/*
+The MIT License
+
+Copyright (c) 2015, Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+* shutdown jenkins CLI
+*
+* as advised in https://github.com/jenkinsci-cert/SECURITY-218, this script
+* will shutdown the Jenkins CLI components, which are a security concern for
+* the version of Jenkins we are currently running.
+*
+**/
+
+import jenkins.*;
+import jenkins.model.*;
+import hudson.model.*;
+
+// disabled CLI access over TCP listener (separate port)
+def p = AgentProtocol.all()
+p.each { x ->
+  if (x.name.contains("CLI")) {
+    p.remove(x)
+  }
+}
+
+// disable CLI access over /cli URL
+def removal = { lst ->
+    lst.each { x ->
+        if (x.getClass().name.contains("CLIAction")) {
+            lst.remove(x)
+        }
+    }
+}
+Jenkins jenkins = Jenkins.getInstance()
+removal(jenkins.getExtensionList(RootAction.class))
+removal(jenkins.actions)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 jenkinsapi==0.3.4
 pytest==3.1.2
+requests==2.9.1


### PR DESCRIPTION
There are a couple of things in this PR:
* Allow an env var pointing to the config yamls to be consumed by the docker container (again, I plan on changing this to be passed directly as yaml, not as files in the future)
* Add an additional script to fail if desired plugins are not installed AND loaded in jenkins
* Add a script to disable the jenkins CLI endpoints, as they are a security concern for older versions of Jenkins