### PR TITLE
Automate Logger Creation

### DIFF
--- a/e2e/pages/configuration_page.py
+++ b/e2e/pages/configuration_page.py
@@ -1,4 +1,3 @@
-
 from bok_choy.page_object import PageObject
 
 class JenkinsConfigurationPage(PageObject):

--- a/e2e/pages/ghprb_log_configure_page.py
+++ b/e2e/pages/ghprb_log_configure_page.py
@@ -1,0 +1,16 @@
+from bok_choy.page_object import PageObject
+
+class GhprbLogConfigurePage(PageObject):
+
+    url = 'http://localhost:8080/log/Ghprb/configure'
+
+    def is_browser_on_page(self):
+        return self.q(css='[class="setting-input  auto-complete  yui-ac-input"]').is_present()
+
+    def get_log_recorder_name(self):
+        return self.q(css='[name="_.name"]').attrs('value')[0]
+
+    def get_loggers_with_level(self):
+        logger_names = self.q(css='[class="setting-input  auto-complete  yui-ac-input"]').attrs('value')
+        level = self.q(css='[name="level"] > [selected="true"]').text
+        return zip(logger_names, level)

--- a/e2e/pages/log_recorder_page.py
+++ b/e2e/pages/log_recorder_page.py
@@ -1,0 +1,11 @@
+from bok_choy.page_object import PageObject
+
+class JenkinsLogRecorderPage(PageObject):
+
+    url = 'http://localhost:8080/log'
+
+    def is_browser_on_page(self):
+        return "log [jenkins]" in self.browser.title.lower()
+
+    def get_log_recorders(self):
+        return self.q(css='[id="logRecorders"] > tbody > tr > td > a').text

--- a/e2e/test_ghprb_log_configure_page.py
+++ b/e2e/test_ghprb_log_configure_page.py
@@ -1,0 +1,32 @@
+import unittest
+import yaml
+import os
+from bok_choy.web_app_test import WebAppTest
+from pages.ghprb_log_configure_page import GhprbLogConfigurePage
+
+class TestGhprbLogConfigurePage(WebAppTest):
+
+    def setUp(self):
+        super(TestGhprbLogConfigurePage, self).setUp()
+        config_path = os.getenv('CONFIG_PATH')
+        try:
+            yaml_contents = open(
+                    "{}/log_config.yml".format(config_path), 'r'
+                    ).read()
+        except IOError:
+            pass
+        self.log_config = yaml.load(yaml_contents)
+        self.ghprb_log_configure_page = GhprbLogConfigurePage(self.browser)
+
+    def test_ghprb_configure_page(self):
+        """
+        Ensure the configuration page for our test data log (GHPRB)
+        has the appropriate name and includes all of the name, log_level
+        pairs from the log_config.yml file.
+        """
+        ghprb_log_configure_page = self.ghprb_log_configure_page.visit()
+        assert self.log_config[0]["LOG_RECORDER"] == self.ghprb_log_configure_page.get_log_recorder_name()
+
+        ghprb_loggers = self.ghprb_log_configure_page.get_loggers_with_level()
+        for log in self.log_config[0]["LOGGERS"]:
+            assert (log["name"], log["log_level"]) in ghprb_loggers

--- a/e2e/test_log_recorder_page.py
+++ b/e2e/test_log_recorder_page.py
@@ -1,0 +1,28 @@
+import unittest
+import yaml
+import os
+from bok_choy.web_app_test import WebAppTest
+from pages.log_recorder_page import JenkinsLogRecorderPage
+
+class TestLogRecorderPage(WebAppTest):
+
+    def setUp(self):
+        super(TestLogRecorderPage, self).setUp()
+        config_path = os.getenv('CONFIG_PATH')
+        try:
+            yaml_contents = open(
+                    "{}/log_config.yml".format(config_path), 'r'
+                    ).read()
+        except IOError:
+            pass
+        self.log_config = yaml.load(yaml_contents)
+        self.log_recorder_page = JenkinsLogRecorderPage(self.browser)
+
+    def test_log_recorder_page(self):
+        """
+        Ensure all the desired log recorders are shown
+        on the page.
+        """
+        log_recorder_page = self.log_recorder_page.visit()
+        logRecordersList = log_recorder_page.get_log_recorders()
+        assert self.log_config[0]["LOG_RECORDER"] in logRecordersList

--- a/src/main/groovy/4createLoggers.groovy
+++ b/src/main/groovy/4createLoggers.groovy
@@ -1,0 +1,55 @@
+/**
+*
+* Automates setting up logs in Jenkins.
+* Reads in a log_config.yml file, and creates the specified
+* Log Recorders, along with their respective
+*
+**/
+
+import java.util.logging.Logger
+
+import jenkins.model.*
+import hudson.logging.*
+
+@Grapes([
+    @Grab(group='org.yaml', module='snakeyaml', version='1.17')
+])
+import org.yaml.snakeyaml.Yaml
+
+Logger logger = Logger.getLogger("")
+Jenkins jenkins = Jenkins.getInstance()
+Yaml yaml = new Yaml()
+
+String configPath = System.getenv("JENKINS_CONFIG_PATH")
+String configText = ''
+try {
+    configText = new File("${configPath}/log_config.yml").text
+} catch (FileNotFoundException e) {
+    logger.severe("Cannot find config file path @ ${configPath}/log_config.yml")
+    jenkins.doSafeExit(null)
+    System.exit(1)
+}
+
+List loggingConfig = yaml.load(configText)
+LogRecorderManager manager = jenkins.getLog()
+// Clear any existing log recorders to avoid clutter
+manager.logRecorders.clear()
+
+loggingConfig.each { jenkinsLogRecorder ->
+    // Create a new log recorder, then get the LogRecorder object
+    // once it has been created.
+    manager.doNewLogRecorder(jenkinsLogRecorder.LOG_RECORDER);
+    LogRecorder logRecorderObject = manager.getLogRecorder(jenkinsLogRecorder.LOG_RECORDER)
+    jenkinsLogRecorder.LOGGERS.each { jenkinsLogger ->
+        // For each log, add a target to the LogRecorder with the proper
+        // name and log level.
+        try {
+            LogRecorder.Target target = new LogRecorder.Target(jenkinsLogger.name, jenkinsLogger.log_level)
+            logRecorderObject.targets.add(target)
+        } catch (IllegalArgumentException e) {
+            logger.severe("Invalid value specified for log_level in ${configPath}/log_config.yml")
+            jenkins.doSafeExit(null)
+            System.exit(1)
+        }
+    }
+}

--- a/test_data/log_config.yml
+++ b/test_data/log_config.yml
@@ -1,0 +1,17 @@
+---
+- LOG_RECORDER: 'Ghprb'
+  LOGGERS:
+    - name: 'org.jenkinsci.plugins.ghprb.GhprbPullRequest'
+      log_level: 'ALL'
+    - name: 'org.jenkinsci.plugins.ghprb.GhprbRootAction'
+      log_level: 'ALL'
+    - name: 'org.jenkinsci.plugins.ghprb.GhprbRepository'
+      log_level: 'ALL'
+    - name: 'org.jenkinsci.plugins.ghprb.GhprbGitHub'
+      log_level: 'ALL'
+    - name: 'org.jenkinsci.plugins.ghprb.Ghprb'
+      log_level: 'ALL'
+    - name: 'org.jenkinsci.plugins.ghprb.GhprbTrigger'
+      log_level: 'ALL'
+    - name: 'org.jenkinsci.plugins.ghprb.GhprbBuilds'
+      log_level: 'ALL'


### PR DESCRIPTION
Adds the ability to outline Log Recorders and their respective Loggers (with log level) to a yaml file to automate their creation. Includes our GHPRB logging rules for test data and uses bok-choy testing to verify its success.