### PR TITLE
Fix error checking in scripts

### DIFF
--- a/src/main/groovy/3shutdownCLI.groovy
+++ b/src/main/groovy/3shutdownCLI.groovy
@@ -41,8 +41,9 @@ import hudson.model.*;
 import org.yaml.snakeyaml.Yaml
 
 Logger logger = Logger.getLogger("")
-
+Jenkins jenkins = Jenkins.getInstance()
 Yaml yaml = new Yaml()
+
 String configPath = System.getenv("JENKINS_CONFIG_PATH")
 String configText = ''
 try {
@@ -77,6 +78,5 @@ def removal = { lst ->
 }
 
 logger.info("Removing the Jenkins CLI subsystem")
-Jenkins jenkins = Jenkins.getInstance()
 removal(jenkins.getExtensionList(RootAction.class))
 removal(jenkins.actions)

--- a/src/main/groovy/4configureGHOAuth.groovy
+++ b/src/main/groovy/4configureGHOAuth.groovy
@@ -18,8 +18,9 @@ import org.jenkinsci.plugins.GithubSecurityRealm
 import org.yaml.snakeyaml.Yaml
 
 Logger logger = Logger.getLogger("")
-
+Jenkins jenkins = Jenkins.getInstance()
 Yaml yaml = new Yaml()
+
 String configPath = System.getenv("JENKINS_CONFIG_PATH")
 try {
     configText = new File("${configPath}/security.yml").text
@@ -31,7 +32,6 @@ try {
 securityGroups = yaml.load(configText).SECURITY_GROUPS
 oauthSettings = yaml.load(configText).OAUTH_SETTINGS
 
-Jenkins jenkins = Jenkins.getInstance()
 SecurityRealm github_realm = new GithubSecurityRealm(oauthSettings.GITHUB_WEB_URI,
                                                      oauthSettings.GITHUB_API_URI,
                                                      oauthSettings.CLIENT_ID,

--- a/src/main/groovy/4configureGit.groovy
+++ b/src/main/groovy/4configureGit.groovy
@@ -7,6 +7,7 @@ import jenkins.model.Jenkins
 import org.yaml.snakeyaml.Yaml
 
 Logger logger = Logger.getLogger("")
+Jenkins jenkins = Jenkins.getInstance()
 Yaml yaml = new Yaml()
 
 String configPath = System.getenv("JENKINS_CONFIG_PATH")
@@ -19,8 +20,6 @@ try {
 }
 
 Map gitConfig = yaml.load(configText)
-
-Jenkins jenkins = Jenkins.getInstance()
 
 def gitScm = jenkins.getDescriptorByType(
                 hudson.plugins.git.GitSCM.DescriptorImpl.class

--- a/src/main/groovy/4configureMailerPlugin.groovy
+++ b/src/main/groovy/4configureMailerPlugin.groovy
@@ -16,7 +16,9 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.yaml.snakeyaml.Yaml
 
 Logger logger = Logger.getLogger("")
+Jenkins jenkins = Jenkins.getInstance()
 Yaml yaml = new Yaml()
+
 String configPath = System.getenv("JENKINS_CONFIG_PATH")
 try {
     configText = new File("${configPath}/mailer_config.yml").text
@@ -26,8 +28,6 @@ try {
     System.exit(1)
 }
 Map mailerConfig = yaml.load(configText)
-
-Jenkins jenkins = Jenkins.getInstance()
 
 def descriptor = jenkins.getDescriptorByType(
                     hudson.tasks.Mailer.DescriptorImpl.class


### PR DESCRIPTION
We need to get the current jenkins instance before checking for the config yaml file, otherwise jenkins will not be shut down if the file is missing.