### PR TITLE
display codenarc violations on console for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ addons:
     firefox: '52.0.1'
 
 script:
+    - export CI_SYSTEM='travis'
     - make quality
     - make healthcheck
     - make e2e

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,12 @@ codenarc {
     maxPriority1Violations = 0
     maxPriority2Violations = 0
     maxPriority3Violations = 0
+
+    // Display codenarc violations in the console for travis builds
+    // otherwise, default to creating an html report
+    if (System.getenv('CI_SYSTEM') == 'travis') {
+        reportFormat = 'console'
+    }
 }
 
 task libs(type: Copy) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip

--- a/plugins.gradle
+++ b/plugins.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
   }
   dependencies {
-        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.18.1'
+        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.22.0'
         classpath 'org.yaml:snakeyaml:1.17'
   }
 }


### PR DESCRIPTION
Codenarc console reporting is only available in gradle 4.1+, hence the upgrade.