### PR TITLE
coerce ec2 variable to boolean

### DIFF
--- a/src/main/groovy/4configureEc2Plugin.groovy
+++ b/src/main/groovy/4configureEc2Plugin.groovy
@@ -152,7 +152,7 @@ for (cloudConfig in ec2Config.CLOUDS) {
     // Create the EC2 Cloud and populate it with the AMIs
     AmazonEC2Cloud cloud = new AmazonEC2Cloud(
         cloudConfig.NAME,
-        cloudConfig.USE_INSTANCE_PROFILE_FOR_CREDS,
+        cloudConfig.USE_INSTANCE_PROFILE_FOR_CREDS.toBoolean(),
         cloudConfig.ACCESS_KEY_ID,
         cloudConfig.SECRET_ACCESS_KEY,
         cloudConfig.REGION,


### PR DESCRIPTION
I was seeing EC2 errors when testing the jenkins_common role. The problem is that we store some configuration data in yml files containing groovy sytax (i.e. false), but this is then coerced to python syntax via jinja templates (i.e. False). Then when Jenkins reads this, it incorrectly coerced it to a string.