### PR TITLE
add script to clean and show plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo '     make quality         run codenarc on groovy source and tests'
 	@echo '     make requirements    install requirements for acceptance tests'
 	@echo '     make plugins         install specified Jenkins plugins and their dependencies'
+	@echo '     make show            show the versions of downloaded plugins"
 	@echo '     make e2e             run python acceptance tests against a provisioned docker container'
 
 clean: clean.container clean.ws
@@ -29,6 +30,7 @@ clean.container:
 
 clean.ws:
 	./gradlew clean
+	./gradlew -b plugins.gradle clean
 
 build:
 	docker build -t $(JENKINS_VERSION) --build-arg=CONFIG_PATH=$(CONFIG_PATH) \
@@ -59,3 +61,6 @@ plugins:
 
 e2e:
 	pytest
+
+show:
+	./gradlew -b plugins.gradle show

--- a/plugins.gradle
+++ b/plugins.gradle
@@ -1,3 +1,6 @@
+import java.util.zip.ZipFile
+import java.util.zip.ZipEntry
+import java.util.regex.Matcher
 buildscript {
   repositories {
         mavenCentral()
@@ -53,6 +56,7 @@ task plugins(type: Copy, dependsOn: [clean]){
                 new File("${plugin}.pinned").createNewFile()
             }
         }
+        showDownloadedPlugins()
     }
 }
 
@@ -63,3 +67,27 @@ def parsePluginList() {
     return list
 }
 
+task show {
+    doLast {
+        showDownloadedPlugins()
+    }
+}
+
+// Display the final versions of all plugins after dependency resolution
+void showDownloadedPlugins() {
+    String pluginsPath = System.getenv('PLUGIN_OUTPUT_DIR') ?: 'plugins'
+    println("The following plugins were downloaded to ${pluginsPath}")
+    File pluginPath = new File("${pluginsPath}")
+    pluginPath.listFiles().findAll { it.name =~ '.*jpi$' }.sort { it.name }.each() { plugin ->
+        ZipFile jpiContents = new ZipFile(plugin)
+        ZipEntry manifestFile = jpiContents.entries().find { it.getName() == "META-INF/MANIFEST.MF" }
+        Matcher matcher = jpiContents.getInputStream(manifestFile).text =~ 'Plugin-Version: ([\\.\\d]+)'
+        String pluginName = plugin.name.split('\\.')[0]
+        String version = matcher[0][1]
+        println("${pluginName}: ${version}")
+    }
+}
+
+clean {
+    delete "${pluginsPath}"
+}


### PR DESCRIPTION
The clean mechanism wasn't being called when downloading plugins, thus creating duplicates. Also, gradle will now display the plugins that were downloaded after all of the dependencies were met.