### PR TITLE
Estute/add property script

### DIFF
--- a/src/main/groovy/3setGlobalProperties.groovy
+++ b/src/main/groovy/3setGlobalProperties.groovy
@@ -1,0 +1,31 @@
+/**
+* set global properties
+*
+* There are a fair amount of properties that can only be set as a runtime flag
+* or via the groovy script console. This script provides unified place to load
+* them
+**/
+
+import java.util.logging.Logger
+import hudson.model.*
+@Grapes([
+    @Grab(group='org.yaml', module='snakeyaml', version='1.17')
+])
+import org.yaml.snakeyaml.Yaml
+
+Logger logger = Logger.getLogger("")
+Yaml yaml = new Yaml()
+
+String configPath = System.getenv("JENKINS_CONFIG_PATH")
+String configText = ''
+try {
+    configText = new File("${configPath}/properties_config.yml").text
+} catch (FileNotFoundException e) {
+    logger.severe("Cannot find config file path @ ${configPath}/properties_config.yml")
+    jenkins.doSafeExit(null)
+    System.exit(1)
+}
+
+for (property in yaml.load(configText)) {
+    System.setProperty(property.KEY, property.VALUE)
+}

--- a/test_data/properties_config.yml
+++ b/test_data/properties_config.yml
@@ -1,0 +1,3 @@
+---
+- KEY: "hudson.footerURL"
+  VALUE: "http://www.example.com"


### PR DESCRIPTION
We forgot to add a script that we currently use on build jenkins (set csp policy settings for viewing custom reports). However, I feel like we should just have a script to set generic properties (there are a lot- see: https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties). This will be a lot cleaner and deterministic than relying on runtime flags. If we choose to reformat previously genertated logs (TE-2225), we can use this script.