### PR TITLE
[2x staging] Support our Jenkins 2x plugin versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: groovy
 env:
-    - JENKINS_VERSION='jenkins_1.651.3'
     - JENKINS_VERSION='jenkins_2.60.3'
 
 sudo: required

--- a/README.rst
+++ b/README.rst
@@ -142,4 +142,4 @@ Test the configuration of a running Jenkins instance
 Plugin Versions
 ~~~~~~~~~~~~~~~~~~
 
-The groovy scripts in this repository were developed with the current plugin versions we use here at edx in mind. Jenkins plugins are always changing, and sometimes constructors or other functions that the scripts rely on change as well. Therefore, tweaks may be necessary for this to function properly with your jenkins instance.
+The groovy scripts in this repository are maintained to match the current configuration of our Jenkins instance here at edx (which is running version 2.60.3 of Jenkins). Plugins are always changing, and sometimes constructors or other methods that these scripts rely on change as well. Therefore, tweaks may be necessary for this to function properly with your jenkins instance.

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'javax.servlet:servlet-api:2.4'
     compile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
     compile 'org.kohsuke:github-api:1.70'
-    compile 'org.jenkins-ci.plugins:ghprb:1.30.1@jar'
+    compile 'org.jenkins-ci.plugins:ghprb:1.36.0@jar'
     compile 'com.coravy.hudson.plugins.github:github:1.14.0@jar'
     compile 'org.jenkins-ci.plugins:ec2:1.28@jar'
     compile 'org.jenkins-ci.plugins:matrix-auth:1.2@jar'

--- a/e2e/pages/configuration_page.py
+++ b/e2e/pages/configuration_page.py
@@ -6,7 +6,7 @@ class JenkinsConfigurationPage(PageObject):
     url = "http://{}:8080/configure".format(JENKINS_HOST)
 
     def expand_advanced(self):
-        self.q(css='#yui-gen13-button').click()
+        self.q(css='[class="advancedLink"] > span > span > button').first.click()
 
     def is_browser_on_page(self):
         return 'configure system [jenkins]' in self.browser.title.lower()

--- a/e2e/test_plugin_installations.py
+++ b/e2e/test_plugin_installations.py
@@ -32,7 +32,7 @@ class PluginTestCase(TestCase):
             "cvs": "2.12",
             # The following plugins installed via test_data/plugins.yml
             "ec2": "1.28",
-            "ghprb": "1.30.1",
+            "ghprb": "1.36.0",
             "job-dsl": "1.45",
             "github-oauth": "0.24",
             "gradle": "1.24",
@@ -42,16 +42,16 @@ class PluginTestCase(TestCase):
             # The following plugins should be installed as dependencies for
             # the plugins installed via test_data/plugins.yml
             "node-iterator-api": "1.1",
-            "github": "1.14.0",
+            "github": "1.26.0",
             "plain-credentials": "1.1",
             "credentials": "2.1.8",
             "matrix-project": "1.6",
             "ssh-agent": "1.3",
-            "github-api": "1.71",
+            "github-api": "1.82",
             "git": "2.4.0",
             "git-client": "1.18.0",
             "junit": "1.3",
-            "scm-api": "0.2",
+            "scm-api": "2.0.3",
             "script-security": "1.27",
             "ssh-credentials": "1.11",
             "mapdb-api": "1.0.1.0",

--- a/src/main/groovy/4configureGHPRB.groovy
+++ b/src/main/groovy/4configureGHPRB.groovy
@@ -6,6 +6,7 @@ import java.lang.reflect.Field
 import jenkins.*
 import jenkins.model.*
 import hudson.model.*
+import hudson.util.Secret
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.stapler.*;
 import org.jenkinsci.plugins.ghprb.*;
@@ -63,6 +64,22 @@ json.put('autoCloseFailedPullRequests', ghprbConfig.AUTO_CLOSE_FAILED_PRS);
 json.put('displayBuildErrorsOnDownstreamBuilds', ghprbConfig.DISPLAY_ERRORS_DOWNSTREAM);
 json.put("githubAuth", null);
 
+String blackList = ghprbConfig.BACK_LIST_LABELS;
+if (blackList) {
+    blackList = backList.join(' ');
+} else {
+    blackList = ''
+}
+json.put('blackListLabels', blackList)
+
+String whiteList = ghprbConfig.WHITE_LIST_LABELS;
+if (whiteList) {
+    whiteList = whiteList.join(' ');
+} else {
+    whiteList = ''
+}
+json.put('whiteListLabels', whiteList);
+
 StaplerRequest stapler =  new RequestImpl(
     new Stapler(),
     Mockito.mock(HttpServletRequestWrapper.class),
@@ -74,13 +91,14 @@ descriptor.configure(stapler, json);
 Field githubAuth = descriptor.class.getDeclaredField("githubAuth")
 githubAuth.setAccessible(true)
 githubAuthArray = new ArrayList<GhprbGitHubAuth>()
+Secret sharedSecret = new Secret(ghprbConfig.SHARED_SECRET)
 githubAuthArray.add(new GhprbGitHubAuth(
     ghprbConfig.SERVER_API_URL,
     null,
     ghprbConfig.CREDENTIALS_ID,
     null,
     null,
-    ghprbConfig.SHARED_SECRET)
+    sharedSecret)
 )
 githubAuth.set(descriptor, githubAuthArray)
 descriptor.save()

--- a/src/main/groovy/4configureMaskPasswords.groovy
+++ b/src/main/groovy/4configureMaskPasswords.groovy
@@ -6,6 +6,7 @@
 **/
 
 import java.util.logging.Logger
+import java.nio.file.NoSuchFileException
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarPasswordPair
 
@@ -33,10 +34,15 @@ try {
 
 Map maskPasswordsConfig = yaml.load(configText)
 
-MaskPasswordsConfig plugin = MaskPasswordsConfig.getInstance()
-
-// Clear any existing settings
-plugin.clear()
+MaskPasswordsConfig plugin = null
+try {
+    // If there is an existing configuration, get it and clear it
+    plugin = MaskPasswordsConfig.getInstance()
+    plugin.clear()
+} catch (NoSuchFileException e) {
+    // If not, create a new MaskPasswordsConfig object
+    plugin = new MaskPasswordsConfig()
+}
 
 // Add classes that should automatically be masked
 maskPasswordsConfig.MASKED_PARAMETER_CLASSES.each { maskedClass ->

--- a/test_data/plugins.yml
+++ b/test_data/plugins.yml
@@ -67,7 +67,7 @@
 
 # Desired plugins
 - name: 'ghprb'
-  version: '1.30.1'
+  version: '1.36.0'
   group: 'org.jenkins-ci.plugins'
 - name: 'ec2'
   version: '1.28'
@@ -76,7 +76,7 @@
   version: '1.45'
   group: 'org.jenkins-ci.plugins'
 - name: 'github'
-  version: '1.14.0'
+  version: '1.26.0'
   group: 'com.coravy.hudson.plugins.github'
 - name: 'github-oauth'
   version: '0.24'


### PR DESCRIPTION
Get this repo to support our new 2.60.3 Jenkins instance.

This includes:
* Moving support to Ghprb version 3.60.0
* Fixing the mask passwords plugin to work on first bootup (when there was no previous xml config file)
* Fixing e2e tests. Instead of the configuration page relying on a hardcoded button number, it programmatically finds the first advanced button on the configure page.