### PR TITLE
configure the markup formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     compile 'org.jenkins-ci.plugins:ssh-credentials:1.11@jar'
     compile 'org.jenkins-ci.plugins:gradle:1.24@jar'
     compile 'org.jenkins-ci.plugins:jobConfigHistory:2.10@jar'
+    compile 'org.jenkins-ci.plugins:antisamy-markup-formatter:1.3@jar'
+    compile 'org.kohsuke:owasp-html-sanitizer:r88@jar'
     compile 'org.jvnet.hudson.plugins:hipchat:0.1.9@jar'
     compile 'org.jenkins-ci.plugins:mailer:1.16@jar'
     compile 'org.jenkins-ci.plugins:mask-passwords:2.8@jar'

--- a/test_data/main_config.yml
+++ b/test_data/main_config.yml
@@ -23,5 +23,9 @@ LOCATION:
     ADMIN_EMAIL: 'admin@localhost'
 SHELL:
     EXECUTABLE: '/bin/bash'
+FORMATTER:
+    FORMATTER_TYPE: 'rawhtml'
+    # Note: this option is only available for 'rawhtml' formatters
+    DISABLE_SYNTAX_HIGHLIGHTING: true
 CLI:
     CLI_ENABLED: false


### PR DESCRIPTION
We missed this option in the global configuration. Using an html formatter will allow us to decorate previous builds with formatted metrics and links to pull requests.