### PR TITLE
Script tweaks for jenkins 2.60.3

### DIFF
--- a/e2e/pages/security_page.py
+++ b/e2e/pages/security_page.py
@@ -14,6 +14,14 @@ class SecurityConfigurationPage(PageObject):
         enabled = self.q(css='[name="_.useSecurity"]').attrs('checked')[0]
         return True if enabled == 'true' else False
 
+    def is_cli_remoting_enabled(self):
+        row_id = self.q(css='[name="jenkins-CLI"]').attrs('id')
+        cli_checkbox = self.q(css='[nameref="{}"] > td > [name="_.enabled"]'.format(row_id)).attrs('checked')
+        if cli_checkbox and cli_checkbox[0] == 'true':
+            return True
+        else:
+            return False
+
     def is_gh_oauth_enabled(self):
         """
         return true if 

--- a/e2e/test_security_configuration.py
+++ b/e2e/test_security_configuration.py
@@ -10,12 +10,19 @@ class TestSecurityConfiguration(WebAppTest):
         super(TestSecurityConfiguration, self).setUp()
         config_path = os.getenv('CONFIG_PATH')
         try:
-            yaml_contents = open(
+            security_yaml_contents = open(
                     "{}/security.yml".format(config_path), 'r'
                     ).read()
         except IOError:
             pass
-        self.security_config = yaml.load(yaml_contents)
+        try:
+            main_yaml_contents = open(
+                    "{}/main_config.yml".format(config_path), 'r'
+                    ).read()
+        except IOError:
+            pass
+        self.security_config = yaml.load(security_yaml_contents)
+        self.main_config = yaml.load(main_yaml_contents)
         self.security_page = SecurityConfigurationPage(self.browser)
 
     def test_security(self):
@@ -25,3 +32,4 @@ class TestSecurityConfiguration(WebAppTest):
             for user in group['USERS']:
                 permissions = self.security_page.get_user_permissions(user)
                 assert all([p in group['PERMISSIONS'] for p in permissions])
+        assert self.main_config['CLI']['CLI_ENABLED'] == self.security_page.is_cli_remoting_enabled()

--- a/src/main/groovy/3shutdownCLI.groovy
+++ b/src/main/groovy/3shutdownCLI.groovy
@@ -60,12 +60,15 @@ if (cliEnabled) {
     System.exit(0)
 }
 
+// disable remoting cli
+jenkins.getDescriptor("jenkins.CLI").get().setEnabled(false)
+
 // disabled CLI access over TCP listener (separate port)
 def p = AgentProtocol.all()
 p.each { x ->
-  if (x.name.contains("CLI")) {
-    p.remove(x)
-  }
+    if (x.name && x.name.contains("CLI")) {
+        p.remove(x)
+    }
 }
 
 // disable CLI access over /cli URL

--- a/src/main/groovy/4configureMaskPasswords.groovy
+++ b/src/main/groovy/4configureMaskPasswords.groovy
@@ -6,7 +6,6 @@
 **/
 
 import java.util.logging.Logger
-import java.nio.file.NoSuchFileException
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarPasswordPair
 
@@ -34,15 +33,7 @@ try {
 
 Map maskPasswordsConfig = yaml.load(configText)
 
-MaskPasswordsConfig plugin = null
-try {
-    // If there is an existing configuration, get it and clear it
-    plugin = MaskPasswordsConfig.getInstance()
-    plugin.clear()
-} catch (NoSuchFileException e) {
-    // If not, create a new MaskPasswordsConfig object
-    plugin = new MaskPasswordsConfig()
-}
+MaskPasswordsConfig plugin = new MaskPasswordsConfig()
 
 // Add classes that should automatically be masked
 maskPasswordsConfig.MASKED_PARAMETER_CLASSES.each { maskedClass ->


### PR DESCRIPTION
A few tweaks for our new 2x box.
1- There's a new security configuration option for remoting cli. This script change disables that while still keeping our existing script (ensuring http and ssh are both disabled as well).
2- The mask passwords script was still throwing an exception on first bootup even though I had the try catch. Just create a new object on startup rather than trying to get an existing one.