### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: groovy
 env:
     - JENKINS_VERSION='jenkins_2.60.3'
 
+dist: trusty
 sudo: required
-
-group: deprecated-2017Q2
 
 branches:
   only:
@@ -32,7 +31,7 @@ before_install:
     - export PATH=$PATH:$PWD/geckodriver
     # install requirements and build the container
     - make plugins
-    - make requirements
+    - sudo make requirements
     - cp local_env.sh.sample local_env.sh && source local_env.sh
     - make build
     - make run

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest==3.1.2
 requests==2.9.1
 bok-choy==0.7.1
 PyYAML==3.12
+selenium==3.4.3


### PR DESCRIPTION
Looks like selenium 3.7.0 was causing issues with our current geckodriver/firefox versions. Pinning to a working version.
Also moving to a non-deprecated trusty image.