### PR TITLE
Rollback ec2 plugin version

### DIFF
--- a/e2e/test_plugin_installations.py
+++ b/e2e/test_plugin_installations.py
@@ -31,7 +31,7 @@ class PluginTestCase(TestCase):
             "external-monitor-job": "1.4",
             "cvs": "2.12",
             # The following plugins installed via test_data/plugins.yml
-            "ec2": "1.37",
+            "ec2": "1.36",
             "ghprb": "1.36.0",
             "job-dsl": "1.45",
             "github-oauth": "0.24",
@@ -43,7 +43,7 @@ class PluginTestCase(TestCase):
             # the plugins installed via test_data/plugins.yml
             "ace-editor": "1.0.1",
             "aws-credentials": "1.23",
-            "aws-java-sdk": "1.11.119",
+            "aws-java-sdk": "1.11.37",
             "durable-task": "1.12",
             "bouncycastle-api": "2.16.0",
             "node-iterator-api": "1.5",

--- a/src/main/groovy/4configureEc2Plugin.groovy
+++ b/src/main/groovy/4configureEc2Plugin.groovy
@@ -104,7 +104,6 @@ for (cloudConfig in ec2Config.CLOUDS) {
             amiConfig.NUM_EXECUTORS,
             amiConfig.REMOTE_ADMIN,
             amiConfig.ROOT_COMMAND_PREFIX,
-            amiConfig.SLAVE_COMMAND_PREFIX,
             amiConfig.JVM_OPTIONS,
             amiConfig.STOP_ON_TERMINATE,
             amiConfig.SUBNET_ID,

--- a/test_data/ec2_config.yml
+++ b/test_data/ec2_config.yml
@@ -26,7 +26,6 @@ CLOUDS:
             NUM_EXECUTORS: '10'
             REMOTE_ADMIN: 'root-admin'
             ROOT_COMMAND_PREFIX: 'root-command'
-            SLAVE_COMMAND_PREFIX: 'slave-command'
             JVM_OPTIONS: 'jvm-option-1'
             STOP_ON_TERMINATE: false
             SUBNET_ID: 'subnet-123'
@@ -60,7 +59,6 @@ CLOUDS:
             NUM_EXECUTORS: '10'
             REMOTE_ADMIN: 'root-admin'
             ROOT_COMMAND_PREFIX: 'root-command'
-            SLAVE_COMMAND_PREFIX: 'slave-command'
             JVM_OPTIONS: 'jvm-option-1'
             STOP_ON_TERMINATE: false
             SUBNET_ID: 'subnet-123'

--- a/test_data/plugins.yml
+++ b/test_data/plugins.yml
@@ -76,7 +76,7 @@
   version: '1.36.0'
   group: 'org.jenkins-ci.plugins'
 - name: 'ec2'
-  version: '1.37'
+  version: '1.36'
   group: 'org.jenkins-ci.plugins'
 - name: 'job-dsl'
   version: '1.45'


### PR DESCRIPTION
Looks like ec2 1.37 was causing problems with scaling, so we're moving down to 1.36.