### PR TITLE
Behind proxy with intellij

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ local_env.sh
 # ignore the files downloaded to build out Jenkins
 plugins/*
 utils/*
+
+# ignore intellij idea files
+/.idea*
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 USER root
 RUN apt-get update -y \
-    && apt-get install -y openjdk-8-jdk \
+    && apt-get install -y openjdk-8-jdk-headless \
     && apt-get install -y curl \
     && apt-get install -y git \
     && apt-get install -y sudo \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,32 @@ SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 .PHONY: clean requirements plugins build logs e2e show run
 
+ifneq ($(http_proxy),)
+DOCKER_BUILD_OPTS += --build-arg http_proxy=$(http_proxy) --build-arg HTTP_PROXY=$(http_proxy)
+endif
+
+ifneq ($(https_proxy),)
+DOCKER_BUILD_OPTS += --build-arg https_proxy=$(https_proxy) --build-arg HTTPS_PROXY=$(https_proxy)
+endif
+
+ifneq ($(no_proxy),)
+DOCKER_BUILD_OPTS += --build-arg no_proxy=$(no_proxy) --build-arg NO_PROXY=$(no_proxy)
+endif
+
+ifneq ($(http_proxy),)
+JAVA_OPTS += -Dhttp.proxyHost=$(shell echo $(http_proxy) | sed 's/http:\/\///;s|\/.*||' | cut -d: -f1) -Dhttp.proxyPort=$(shell echo $(http_proxy) | sed 's/http:\/\///;s|\/.*||' | cut -d: -f2)
+endif
+
+ifneq ($(https_proxy),)
+JAVA_OPTS += -Dhttps.proxyHost=$(shell echo $(https_proxy) | sed 's/http:\/\///;s|\/.*||' | cut -d: -f1) -Dhttps.proxyPort=$(shell echo $(https_proxy) | sed 's/http:\/\///;s|\/.*||' | cut -d: -f2)
+endif
+
+ifneq ($(no_proxy),)
+# FIXME: substitution is not complete as UNIX's no_proxy use".mydomain.com" and Java's *.nonProxyHosts uses "*.mydomain.com"
+comma:=,
+JAVA_OPTS += -Dhttp.nonProxyHosts="$(subst $(comma),|,$(no_proxy))" -Dhttps.nonProxyHosts="$(subst $(comma),|,$(no_proxy))"
+endif
+
 help:
 	@echo ''
 	@echo 'Makefile for '
@@ -35,7 +61,7 @@ clean.ws:
 	./gradlew -b plugins.gradle clean
 
 build:
-	docker build -t $(CONTAINER_NAME) --build-arg=CONFIG_PATH=$(CONFIG_PATH) \
+	docker build $(DOCKER_BUILD_OPTS) -t $(CONTAINER_NAME) --build-arg=CONFIG_PATH=$(CONFIG_PATH) \
 		--build-arg=JENKINS_VERSION=$(JENKINS_VERSION) \
 		--build-arg=JENKINS_WAR_SOURCE=$(JENKINS_WAR_SOURCE) .
 
@@ -45,7 +71,7 @@ run.container:
 	docker run --name $(CONTAINER_NAME) -p 8080:8080 -p 2222:22 -d $(CONTAINER_NAME)
 
 run.jenkins:
-	docker exec -d -u jenkins ${CONTAINER_NAME} /usr/bin/java -jar /usr/share/jenkins/jenkins.war --httpPort=8080 --logfile=/var/log/jenkins/jenkins.log
+	docker exec -d -u jenkins ${CONTAINER_NAME} /usr/bin/java $(JAVA_OPTS) -jar /usr/share/jenkins/jenkins.war --httpPort=8080 --logfile=/var/log/jenkins/jenkins.log
 
 logs:
 	docker exec $(CONTAINER_NAME) tail -f /var/log/jenkins/jenkins.log


### PR DESCRIPTION
This small changes set:

1. Enables the Jenkins Docker image to run behind a password-less corporate HTTP proxy
2. Ignores IntelliJ-generated files in Git
3. use the headless JDK in the Docker image instead of the UI-capable one. But wouldn't the simple headless JRE make the job?

It is tested in macOS only, but I think it should run without an issue on Linux.