### PR TITLE
Upgrade jenkins version from 2.60.3 to 2.89.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 env:
-    - JENKINS_VERSION='jenkins_2.60.3'
+    - JENKINS_VERSION='jenkins_2.89.4'
 
 dist: trusty
 sudo: required

--- a/local_env.sh.sample
+++ b/local_env.sh.sample
@@ -11,5 +11,5 @@ export PLUGIN_CONFIG='test_data/plugins.yml'
 # change this variable
 export JENKINS_WAR_SOURCE='https://s3.amazonaws.com/edx-testeng-tools/jenkins'
 
-export JENKINS_VERSION='jenkins_2.60.3'
+export JENKINS_VERSION='jenkins_2.89.4'
 export CONTAINER_NAME='jenkins'

--- a/src/main/groovy/4configureGHOAuth.groovy
+++ b/src/main/groovy/4configureGHOAuth.groovy
@@ -30,8 +30,9 @@ try {
     jenkins.doSafeExit(null)
     System.exit(1)
 }
-securityGroups = yaml.load(configText).SECURITY_GROUPS
-oauthSettings = yaml.load(configText).OAUTH_SETTINGS
+securityConfig = yaml.load(configText)
+securityGroups = securityConfig.SECURITY_GROUPS
+oauthSettings = securityConfig.OAUTH_SETTINGS
 
 SecurityRealm github_realm = new GithubSecurityRealm(oauthSettings.GITHUB_WEB_URI,
                                                      oauthSettings.GITHUB_API_URI,
@@ -88,6 +89,15 @@ securityGroups.each { group ->
         }
     }
 }
-
 jenkins.setAuthorizationStrategy(strategy)
+
+// Configure Agent security settings
+agentConfig = securityConfig.AGENT_SETTINGS
+jenkins.setSlaveAgentPort(agentConfig.JNLP_TCP_PORT)
+Set<String> protocols = new HashSet<String>();
+agentConfig.PROTOCOLS.each { protocol ->
+    protocols.add(protocol)
+}
+jenkins.setAgentProtocols(protocols)
+
 jenkins.save()

--- a/test_data/security.yml
+++ b/test_data/security.yml
@@ -1,4 +1,8 @@
 ---
+AGENT_SETTINGS:
+    PROTOCOLS:
+      - 'JNLP4-connect'
+    JNLP_TCP_PORT: 0
 OAUTH_SETTINGS:
     GITHUB_WEB_URI: 'https://github.com'
     GITHUB_API_URI: 'https://api.github.com'


### PR DESCRIPTION
* Upgrades Jenkins version to 2.89.4 (The latest version we can move to while still using the build flow plugin)
* Introduces new config for agent protocols

This upgrade introduces a warning that the agent protocol used between master and jenkins workers is deprecated (more on those here: https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp2-connect-errata). I added some config to update it without any manual config needed.

There is also a warning saying that the "Prevent Cross Site Request Forgery exploits" should be enabled on our security page, but that has more implications to it... so I think it deserves its own ticket.