### PR TITLE
Update the job-dsl plugin for Pipelines support

### DIFF
--- a/e2e/test_plugin_installations.py
+++ b/e2e/test_plugin_installations.py
@@ -33,7 +33,7 @@ class PluginTestCase(TestCase):
             # The following plugins installed via test_data/plugins.yml
             "ec2": "1.28",
             "ghprb": "1.36.0",
-            "job-dsl": "1.45",
+            "job-dsl": "1.68",
             "github-oauth": "0.24",
             "gradle": "1.24",
             "hipchat": "0.1.9",
@@ -57,7 +57,7 @@ class PluginTestCase(TestCase):
             "script-security": "1.27",
             "ssh-credentials": "1.12",
             "mapdb-api": "1.0.1.0",
-            "structs": "1.6",
+            "structs": "1.13",
             "token-macro": "1.11",
             "ace-editor": "1.0.1",
             "authentication-tokens": "1.1",

--- a/test_data/plugins.yml
+++ b/test_data/plugins.yml
@@ -73,7 +73,7 @@
   version: '1.28'
   group: 'org.jenkins-ci.plugins'
 - name: 'job-dsl'
-  version: '1.45'
+  version: '1.68'
   group: 'org.jenkins-ci.plugins'
 - name: 'github'
   version: '1.26.0'


### PR DESCRIPTION
1.47 is the minimum version that supports Pipeline.