### PR TITLE
update the seed job

### DIFF
--- a/test_data/xml/seed_job.xml
+++ b/test_data/xml/seed_job.xml
@@ -12,6 +12,14 @@
         <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
+    <jenkins.advancedqueue.AdvancedQueueSorterJobProperty plugin="PrioritySorter@2.9">
+      <useJobPriority>false</useJobPriority>
+      <priority>-1</priority>
+    </jenkins.advancedqueue.AdvancedQueueSorterJobProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
@@ -27,7 +35,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.2.4">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.8.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -43,7 +51,8 @@
     <submoduleCfg class="list"/>
     <extensions/>
   </scm>
-  <canRoam>true</canRoam>
+  <assignedNode>dsl-seed-runner</assignedNode>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
@@ -64,7 +73,7 @@
       <description>tert</description>
       <switches></switches>
       <tasks>libs
-      assemble</tasks>
+assemble</tasks>
       <rootBuildScriptDir></rootBuildScriptDir>
       <buildFile></buildFile>
       <gradleName>(Default)</gradleName>
@@ -73,7 +82,7 @@
       <fromRootBuildScriptDir>true</fromRootBuildScriptDir>
       <useWorkspaceAsHome>true</useWorkspaceAsHome>
     </hudson.plugins.gradle.Gradle>
-    <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.45">
+    <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.47">
       <targets>${DSL_SCRIPT}</targets>
       <usingScriptText>false</usingScriptText>
       <ignoreExisting>false</ignoreExisting>
@@ -81,7 +90,7 @@
       <removedViewAction>IGNORE</removedViewAction>
       <lookupStrategy>JENKINS_ROOT</lookupStrategy>
       <additionalClasspath>lib/snakeyaml-1.17.jar
-      src/main/groovy</additionalClasspath>
+src/main/groovy</additionalClasspath>
     </javaposse.jobdsl.plugin.ExecuteDslScripts>
   </builders>
   <publishers/>


### PR DESCRIPTION
Among other things, this will:

* Fix the "assignedNode" tag to allow this job to run on instances
  labeled "dsl-seed-runner".  Otherwise, this job will not run at all.

* Correct indentation for multi-line text areas, including
  "additionalClasspath".  Otherwise this job is guaranteed to fail.

* Update some hard-coded plugin versions, apparently.