### PR TITLE
remove flaky ghprb test

### DIFF
--- a/e2e/test_ghprb_plugin_configuration.py
+++ b/e2e/test_ghprb_plugin_configuration.py
@@ -29,6 +29,5 @@ class TestGHPRBConfiguration(WebAppTest):
         self.config_page.expand_advanced()
         # test some advanced components of the GHPRB config
         assert self.ghprb_config['REQUEST_TESTING_PHRASE'] == self.config_page.get_request_testing_phrase()
-        assert ' '.join(self.ghprb_config['BLACK_LIST_LABELS']) == self.config_page.get_black_list_labels()
         # test one of the extension configurations of the GHPRB
         assert str(self.ghprb_config['BUILD_LOG_LINES_TO_DISPLAY']) == self.config_page.get_build_log_portion() == '25'


### PR DESCRIPTION
This test often fails due to the size of the Jenkins configuration page being difficult to scroll on. With this removed, the tests should be more reliable