### PR TITLE
Estute/te 232

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: groovy
-env:
-    - JENKINS_VERSION='jenkins_2.89.4'
+
+matrix:
+  include:
+  - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.89.4'
+  - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.89.4'
 
 dist: trusty
 sudo: required

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ clean.ws:
 build:
 	docker build -t $(CONTAINER_NAME) --build-arg=CONFIG_PATH=$(CONFIG_PATH) \
 		--build-arg=JENKINS_VERSION=$(JENKINS_VERSION) \
-		--build-arg=JENKINS_WAR_SOURCE=$(JENKINS_WAR_SOURCE) .
+		--build-arg=JENKINS_WAR_SOURCE=$(JENKINS_WAR_SOURCE) \
+		--target=$(TEST_SHARD) .
 
 run: run.container run.jenkins
 

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,9 @@ Before running anything the following environment variables must be set:
     - PLUGIN_CONFIG -> path the yml config file containing the desired plugin
         version names and versions to be installed prior to Jenkins initialization
     - CONTAINER_NAME -> name of the docker container that gets created
+    - TEST_SHARD -> used to specify which set of scripts will be used to
+        configure a Jenkins container and which tests should be run against
+        said container.
 
 This can be done by copying local_env.sample.sh, making the modifications you
 need, and running:

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     compile 'org.jenkins-ci.plugins:mask-passwords:2.8@jar'
     compile 'com.amazonaws:aws-java-sdk:1.11.178'
     compile 'com.splunk.splunkins:splunk-devops:1.6.4@jar'
+    compile 'org.jenkins-ci.plugins:saml:1.1.0@jar'
+    compile 'org.pac4j:pac4j-saml:1.9.9'
     testCompile 'org.codehaus.groovy:groovy-all:2.1.3'
     testCompile 'javax.servlet:servlet-api:2.4'
     testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"

--- a/e2e/pages/security_page.py
+++ b/e2e/pages/security_page.py
@@ -28,11 +28,21 @@ class SecurityConfigurationPage(PageObject):
 
     def is_gh_oauth_enabled(self):
         """
-        return true if he `GitHub Web URI` field is present, which will only
+        return true if the `GitHub Web URI` field is present, which will only
         appear when GH OAuth is selected, rather than the GH OAuth radio button,
         which has no unique CSS identifier
         """
-        return self.q(css='[name="_.githubWebUri"]').present
+        return self.q(css='[name="_.githubWebUri"]').visible
+
+
+    def is_saml_enabled(self):
+        """
+        return true if the `IdpMetadataConfiguration/checkXml` field is present,
+        which will only appear when SAML is selected, rather than the SAML radio button,
+        which has no unique CSS identifier
+        """
+        css_query = '[checkurl="/descriptorByName/org.jenkinsci.plugins.saml.IdpMetadataConfiguration/checkXml"]'
+        return self.q(css=css_query).visible
 
     def get_user_permissions(self, user):
         """

--- a/e2e/test_security_configuration.py
+++ b/e2e/test_security_configuration.py
@@ -1,8 +1,13 @@
 import unittest
 import yaml
 import os
+
+import pytest
+
 from bok_choy.web_app_test import WebAppTest
 from pages.security_page import SecurityConfigurationPage
+
+test_shard = os.getenv('TEST_SHARD')
 
 class TestSecurityConfiguration(WebAppTest):
 
@@ -27,7 +32,6 @@ class TestSecurityConfiguration(WebAppTest):
 
     def test_security(self):
         self.security_page.visit()
-        assert self.security_page.is_gh_oauth_enabled()
         for group in self.security_config['SECURITY_GROUPS']:
             for user in group['USERS']:
                 permissions = self.security_page.get_user_permissions(user)
@@ -35,3 +39,13 @@ class TestSecurityConfiguration(WebAppTest):
         assert self.main_config['CLI']['CLI_ENABLED'] == self.security_page.is_cli_remoting_enabled()
         assert self.security_config['DSL_SCRIPT_SECURITY_ENABLED'] == self.security_page.is_dsl_script_security_enabled()
         assert self.security_config['CSRF_PROTECTION_ENABLED'] == self.security_page.is_csrf_protection_enabled()
+
+    @pytest.mark.skipif(test_shard != 'shard_1', reason='incorrect shard value')
+    def test_gh_oauth_enabled(self):
+        self.security_page.visit()
+        assert self.security_page.is_gh_oauth_enabled()
+
+    @pytest.mark.skipif(test_shard != 'shard_2', reason='incorrect shard value')
+    def test_saml_enabled(self):
+        self.security_page.visit()
+        assert self.security_page.is_saml_enabled()

--- a/local_env.sh.sample
+++ b/local_env.sh.sample
@@ -13,3 +13,8 @@ export JENKINS_WAR_SOURCE='https://s3.amazonaws.com/edx-testeng-tools/jenkins'
 
 export JENKINS_VERSION='jenkins_2.89.4'
 export CONTAINER_NAME='jenkins'
+
+# specify the shard to use when building a docker container. the
+# shard value is used to specify which scripts are copied into the
+# docker container AND which tests should be run against the container
+# export TEST_SHARD=shard_1

--- a/src/main/groovy/4configureGHOAuth.groovy
+++ b/src/main/groovy/4configureGHOAuth.groovy
@@ -25,7 +25,7 @@ String configPath = System.getenv("JENKINS_CONFIG_PATH")
 try {
     configText = new File("${configPath}/github_oauth.yml").text
 } catch (FileNotFoundException e) {
-    logger.severe("Cannot find config file path @ ${configPath}/security.yml")
+    logger.severe("Cannot find config file path @ ${configPath}/github_oauth.yml")
     jenkins.doSafeExit(null)
     System.exit(1)
 }

--- a/src/main/groovy/4configureSAML.groovy
+++ b/src/main/groovy/4configureSAML.groovy
@@ -1,0 +1,107 @@
+/**
+* Configure the SAML plugin
+**/
+
+import java.util.logging.Logger
+
+import jenkins.model.Jenkins
+import hudson.util.Secret
+import org.jenkinsci.plugins.saml.SamlSecurityRealm
+import org.jenkinsci.plugins.saml.SamlAdvancedConfiguration
+import org.jenkinsci.plugins.saml.SamlEncryptionData
+import org.jenkinsci.plugins.saml.IdpMetadataConfiguration
+import org.jenkinsci.plugins.saml.conf.AttributeEntry
+import org.jenkinsci.plugins.saml.conf.Attribute
+import static org.opensaml.saml.common.xml.SAMLConstants.SAML2_POST_BINDING_URI
+import static org.opensaml.saml.common.xml.SAMLConstants.SAML2_REDIRECT_BINDING_URI
+
+@Grapes([
+    @Grab(group='org.yaml', module='snakeyaml', version='1.17')
+])
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+
+Logger logger = Logger.getLogger("")
+Jenkins jenkins = Jenkins.getInstance()
+Yaml yaml = new Yaml(new SafeConstructor())
+
+String configPath = System.getenv("JENKINS_CONFIG_PATH")
+try {
+    configText = new File("${configPath}/saml_config.yml").text
+} catch (FileNotFoundException e) {
+    logger.severe("Cannot find config file path @ ${configPath}/saml_config.yml")
+    jenkins.doSafeExit(null)
+    System.exit(1)
+}
+
+samlConfigs = yaml.load(configText)
+
+IdpMetadataConfiguration idpMetadata = new IdpMetadataConfiguration(samlConfigs.IDP_METADATA)
+int maximumAuthenticationLifetime = samlConfigs.MAX_AUTH_LIFETIME_SECONDS.toInteger()
+
+if (!samlConfigs.ADVANCED_CONFIGURATION.isEmpty()) {
+    advancedConfiguration = new SamlAdvancedConfiguration(
+        samlConfigs.ADVANCED_CONFIGURATION.FORCE_AUTH,
+        samlConfigs.ADVANCED_CONFIGURATION.CONTEXT_CLASS_REF,
+        samlConfigs.ADVANCED_CONFIGURATION.ENTITY_ID,
+        samlConfigs.ADVANCED_CONFIGURATION.MAXIMUM_SESSION_LIFETIME
+    )
+} else {
+    advancedConfiguration = null
+}
+
+if (!samlConfigs.ENCRYPTION_DATA.isEmpty()) {
+    encryptionData = new SamlEncryptionData(
+        samlConfigs.ENCRYPTION_DATA.KEY_STORE_PATH,
+        Secret.fromString(samlConfigs.ENCRYPTION_DATA.KEY_STORE_PASSWORD),
+        Secret.fromString(samlConfigs.ENCRYPTION_DATA.PRIVATE_KEY_PASSWORD),
+        samlConfigs.ENCRYPTION_DATA.PRIVATE_KEY_ALIAS,
+        samlConfigs.ENCRYPTION_DATA.FORCE_SIGN_REDIRECT_BINDING_AUTH_REQUEST
+    )
+} else {
+    encryptionData = null
+}
+
+ArrayList<String> conventions = ['none', 'lowercase', 'uppercase']
+if (!conventions.contains(samlConfigs.USERNAME_CASE_CONVENTION)) {
+    logger.severe("USERNAME_CASE_CONVENTION must be one of ${conventions}")
+    jenkins.doSafeExit(null)
+    System.exit(1)
+}
+
+String binding = ''
+if (samlConfigs.BINDING == 'POST') {
+    binding = SAML2_POST_BINDING_URI.toString()
+} else if (samlConfigs == 'REDIRECT') {
+    binding = SAML2_REDIRECT_BINDING_URI.toString()
+} else {
+    logger.severe("Invalid binding ${samlConfigs.BINDING}. Options are: 'POST' and 'REDIRECT'")
+    jenkins.doSafeExit(null)
+    System.exit(1)
+}
+
+ArrayList<AttributeEntry> attributes = new ArrayList<AttributeEntry>()
+samlConfigs.SAML_CUSTOM_ATTRIBUTES.each { attr ->
+    Attribute attribute = new Attribute(attr.ATTRIBUTE_NAME, attr.ATTRIBUTE_VALUE)
+    attributes.add(attribute)
+}
+
+SamlSecurityRealm securityRealm = new SamlSecurityRealm(
+    idpMetadata,
+    samlConfigs.DISPLAY_NAME_ATTRIBUTE,
+    samlConfigs.GROUP_ATTRIBUTE,
+    maximumAuthenticationLifetime,
+    samlConfigs.USERNAME_ATTRIBUTE,
+    samlConfigs.EMAIL_ATTRIBUTE,
+    samlConfigs.LOGOUT_URL,
+    advancedConfiguration,
+    encryptionData,
+    samlConfigs.USERNAME_CASE_CONVENTION,
+    binding,
+    attributes
+)
+
+jenkins.setSecurityRealm(securityRealm)
+jenkins.save()
+
+logger.info('Successfully Configured the SAML plugin')

--- a/test_data/plugins.yml
+++ b/test_data/plugins.yml
@@ -108,3 +108,6 @@
 - name: 'email-ext'
   version: '2.62'
   group: 'org.jenkins-ci.plugins'
+- name: 'saml'
+  version: '1.1.0'
+  group: 'org.jenkins-ci.plugins'

--- a/test_data/saml_config.yml
+++ b/test_data/saml_config.yml
@@ -1,0 +1,29 @@
+---
+IDP_METADATA: |
+    <xml> this is some idp xml data </xml>
+DISPLAY_NAME_ATTRIBUTE: 'def'
+GROUP_ATTRIBUTE: 'ghi'
+MAX_AUTH_LIFETIME_SECONDS: 10
+USERNAME_ATTRIBUTE: 'jkl'
+EMAIL_ATTRIBUTE: 'mno'
+LOGOUT_URL: 'https://www.example.com/logout'
+# Optional. Set ADVANCED_CONFIGURATION to {} if you do not want to use it
+ADVANCED_CONFIGURATION:
+    FORCE_AUTH: true
+    CONTEXT_CLASS_REF: 'yyy'
+    ENTITY_ID: 'zzz'
+    MAXIMUM_SESSION_LIFETIME: 99
+# Optional. Set ENCRYPTION_DATA to {} if you do not want to use it
+ENCRYPTION_DATA:
+    KEY_STORE_PATH: 'aaa'
+    KEY_STORE_PASSWORD: 'bbb'
+    PRIVATE_KEY_PASSWORD: 'ccc'
+    PRIVATE_KEY_ALIAS: 'ddd'
+    FORCE_SIGN_REDIRECT_BINDING_AUTH_REQUEST: true
+# USERNAME_CASE_CONVENTION must be 'uppercase', 'lowercase' or 'none'
+USERNAME_CASE_CONVENTION: 'uppercase'
+# BINDING must be 'POST' OR 'REDIRECT'
+BINDING: 'POST'
+SAML_CUSTOM_ATTRIBUTES:
+    - ATTRIBUTE_NAME: 'name'
+      ATTRIBUTE_VALUE: 'val'

--- a/test_data/xml/idp_metadata.xml
+++ b/test_data/xml/idp_metadata.xml
@@ -1,0 +1,3 @@
+<xml>
+    this is the idp metadata!
+</xml>


### PR DESCRIPTION
UPDATE (11/5): I have changed this pr to use the Docker multi-stage pattern. Basically, the docker file is split into sections with target names; a common base target, and two shard targets. Each target copes a selection of scripts into the init directory. Instead of specifying this with the `AUTH_MECHANISM` environment URL, I am using a more general 'TEST_SHARD' variable.

UPDATED: The main focus of the PR is to add scripting for configuring the SAML plugin. However, due to the fact that Jenkins cannot use more than one authentication mechanism (in the case of this repo, we have scripts for Github OAauth and now SAML), I needed to add in some additional logic to allow testing of both mechanisms. The environment variable `AUTH_MECHANISM` is used to specify which scripts to copy over (I have moved the auth related scripts into their own directories) as well as specify which tests should run. In order to test both, I have also created a matrix in the travis file, running one container with GH Oauth and one with SAML. All of the other scripts are copied to both. This works for now, but I would love feedback on this.