### PR TITLE
Estute/hris 246

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ CMD ["/usr/sbin/sshd", "-D"]
 
 FROM base as shard_2
 COPY src/main/groovy/4configureSAML.groovy \
+    src/main/groovy/3addUsers.groovy \
     $JENKINS_HOME/init.groovy.d/
 RUN chown -R jenkins:jenkins $JENKINS_HOME /var/log/jenkins
 

--- a/e2e/pages/people_page.py
+++ b/e2e/pages/people_page.py
@@ -1,0 +1,13 @@
+from . import JENKINS_HOST
+from bok_choy.page_object import PageObject
+
+class PeoplePage(PageObject):
+
+    url = "http://{}:8080/asynchPeople".format(JENKINS_HOST)
+
+    def is_browser_on_page(self):
+        return "People" in self.q(css='[id="main-panel"] > h1').text
+
+    def get_number_users(self):
+        # Find the number of rows in the table, but subtract one for the headers
+        return len(self.q(css='[class="sortable pane bigtable"] > tbody > tr')) - 1

--- a/e2e/test_people_page.py
+++ b/e2e/test_people_page.py
@@ -1,0 +1,34 @@
+import unittest
+import yaml
+import os
+
+import pytest
+
+from bok_choy.web_app_test import WebAppTest
+from pages.people_page import PeoplePage
+
+test_shard = os.getenv('TEST_SHARD')
+
+class TestConfiguration(WebAppTest):
+    
+    def setUp(self):
+        super(TestConfiguration, self).setUp()
+        config_path = os.getenv('CONFIG_PATH')
+        try:
+            yaml_contents = open(
+                    "{}/user_config.yml".format(config_path), 'r'
+                    ).read()
+        except IOError:
+            self.fail("Unable to load {}/user_config.yml".format(config_path))
+        self.users = yaml.safe_load(yaml_contents)
+        self.people_page = PeoplePage(self.browser)
+
+    @pytest.mark.skipif(test_shard != 'shard_2', reason='incorrect shard value')
+    def test_user_creation(self):
+        """
+        Test the people table to see if the correct number of users has been created
+        """
+        people_page = self.people_page.visit()
+        # check the number of created users. 'System' will already
+        # be created, so exclude them from the test
+        assert len(self.users) == people_page.get_number_users() - 1

--- a/src/main/groovy/3addUsers.groovy
+++ b/src/main/groovy/3addUsers.groovy
@@ -1,0 +1,61 @@
+/**
+* Create Jenkins users
+*
+* This script is used for creating basic Jenkins users and setting basic
+* information, such as email addresses. This is necessary if you choose
+* to use SAML authentication, as user accounts are required on both the
+* Identity Provider and Service Provider.
+*
+* This script must be run before you set the Security Realm for your Jenkins
+* (i.e. Github Oauth, Saml). Otherwise, it will overwrite it, and set the
+* Jenkins Security Realm to 'Jenkins’ own user database'
+**/
+
+import java.util.logging.Logger
+import jenkins.model.Jenkins
+import hudson.model.User
+import hudson.security.HudsonPrivateSecurityRealm
+import hudson.tasks.Mailer.UserProperty
+
+@Grapes([
+    @Grab(group='org.yaml', module='snakeyaml', version='1.17')
+])
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+
+Logger logger = Logger.getLogger("")
+Jenkins jenkins = Jenkins.getInstance()
+Yaml yaml = new Yaml(new SafeConstructor())
+
+String configPath = System.getenv("JENKINS_CONFIG_PATH")
+try {
+    configText = new File("${configPath}/user_config.yml").text
+} catch (FileNotFoundException e) {
+    logger.severe("Cannot find config file path @ ${configPath}/user_config.yml")
+    jenkins.doSafeExit(null)
+    System.exit(1)
+}
+
+userConfigs = yaml.load(configText)
+
+HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false)
+
+int userCount = 0
+userConfigs.each { userData ->
+
+    Collection<User> allUsers = User.getAll().collect { u -> u.getId() }
+    if (!allUsers.contains(userData.USERNAME)) {
+       realm.createAccount(userData.USERNAME, userData.PASSWORD)
+    }
+    User user = realm.getUser(userData.USERNAME)
+
+    UserProperty emailAddressProperty = new UserProperty(userData.EMAIL_ADDRESS)
+    user.addProperty(emailAddressProperty)
+    user.save()
+    userCount += 1
+
+}
+
+jenkins.setSecurityRealm(realm)
+jenkins.save()
+logger.info("Successfully created ${userCount.toString()} users")

--- a/test_data/user_config.yml
+++ b/test_data/user_config.yml
@@ -1,0 +1,10 @@
+---
+- USERNAME: "user1"
+  PASSWORD: "dummy-data"
+  EMAIL_ADDRESS: "user1@example.com"
+- USERNAME: "user2"
+  PASSWORD: "dummy-data"
+  EMAIL_ADDRESS: "user2@example.com"
+- USERNAME: "user3"
+  PASSWORD: "dummy-data"
+  EMAIL_ADDRESS: "user3@example.com"


### PR DESCRIPTION
In order to provide SAML auth on Jenkins, users with email addresses corresponding to GSuite users must be present in the Jenkins user system. This script adds them from a secret file. 