### PR TITLE
update version of jenkins ci plugin

### DIFF
--- a/plugins.gradle
+++ b/plugins.gradle
@@ -1,6 +1,7 @@
 import java.util.zip.ZipFile
 import java.util.zip.ZipEntry
 import java.util.regex.Matcher
+
 buildscript {
   repositories {
         mavenCentral()
@@ -13,6 +14,11 @@ buildscript {
         classpath 'org.yaml:snakeyaml:1.17'
   }
 }
+
+plugins {
+    id 'org.jenkins-ci.jpi' version '0.28.1'
+}
+
 apply plugin: 'groovy'
 apply plugin: 'java'
 apply plugin: 'org.jenkins-ci.jpi'


### PR DESCRIPTION
Versions of the jenkins-ci gradle plugin prior to 0.8.0 were not compatible with Java 1.8+. Upgrade to the most recent version of the plugin.