### PR TITLE
TE-2854 Upgrade Firefox, bok-choy, and selenium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ plugins/*
 utils/*
 
 # ignore artifacts from e2e tests
+.tox/
 geckodriver.log
+logs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py27
   - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py27
 
-dist: trusty
+dist: xenial
 sudo: required
 
 branches:
@@ -26,11 +26,9 @@ cache:
 
 before_install:
     # browser set up for e2e tests
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
-    - wget https://s3.amazonaws.com/vagrant.testeng.edx.org/geckodriver-v0.15.0-linux64.tar.gz
+    - wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
     - mkdir geckodriver
-    - tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver
+    - tar -xzf geckodriver-v0.24.0-linux64.tar.gz -C geckodriver
     - export PATH=$PATH:$PWD/geckodriver
     # install requirements and build the container
     - make plugins
@@ -38,9 +36,10 @@ before_install:
     - cp local_env.sh.sample local_env.sh && source local_env.sh
     - make build
     - make run
+    - export BOKCHOY_HEADLESS=true
 
 addons:
-    firefox: '52.0.1'
+    firefox: '69.0'
 
 script:
     - export CI_SYSTEM='travis'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: groovy
+jdk: openjdk8
 
 matrix:
   include:

--- a/e2e/pages/configuration_page.py
+++ b/e2e/pages/configuration_page.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.action_chains import ActionChains
+
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
 
@@ -6,7 +8,8 @@ class JenkinsConfigurationPage(PageObject):
     url = "http://{}:8080/configure".format(JENKINS_HOST)
 
     def expand_advanced(self):
-        self.q(css='[class="advancedLink"] > span > span > button').first.click()
+        element = self.browser.find_element_by_css_selector('[class="advancedLink"] > span > span > button')
+        ActionChains(self.browser).move_to_element(element).click(element)
 
     def is_browser_on_page(self):
         return 'configure system [jenkins]' in self.browser.title.lower()
@@ -50,9 +53,9 @@ class ConfigurationSubPageMixIn(object):
     def expand_advanced(self):
         """ Press the "Advanced" button for the plugin section."""
         nameref_id = self.q(css='[name="{}"]'.format(self.name)).attrs('id')[0]
-        css_query='[nameref="{}"] > td > div.advancedLink > span.yui-button'.format(nameref_id)
-        self.scroll_to_element(css_query)
-        self.q(css=css_query).click()
+        css_query = '[nameref="{}"] > td > div.advancedLink > span.yui-button button'.format(nameref_id)
+        element = self.browser.find_element_by_css_selector(css_query)
+        ActionChains(self.browser).move_to_element(element).click(element)
 
     def values_of_elements_named(self, el_name):
         """

--- a/local_env.sh.sample
+++ b/local_env.sh.sample
@@ -18,3 +18,7 @@ export CONTAINER_NAME='jenkins'
 # shard value is used to specify which scripts are copied into the
 # docker container AND which tests should be run against the container
 # export TEST_SHARD=shard_1
+
+# Save artifacts on bok-choy test failures
+export SCREENSHOT_DIR=logs
+export SELENIUM_DRIVER_LOG_DIR=logs

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,11 +6,11 @@
 #
 atomicwrites==1.3.0
 attrs==19.1.0
-bok-choy==0.7.1
+bok-choy==1.0.0
 certifi==2019.6.16
 chardet==3.0.4
 click==7.0
-configparser==3.8.1
+configparser==4.0.1
 contextlib2==0.5.5
 filelock==3.0.12
 funcsigs==1.0.2
@@ -19,11 +19,8 @@ importlib-metadata==0.20
 jenkinsapi==0.3.9
 lazy==1.4
 more-itertools==5.0.0
-needle==0.5.0
-nose==1.3.7
 packaging==19.1
 pathlib2==2.3.4
-pillow==6.1.0
 pip-tools==4.1.0
 pluggy==0.12.0
 py==1.8.0
@@ -33,7 +30,7 @@ pytz==2019.2
 pyyaml==5.1.2
 requests==2.22.0
 scandir==1.10.0
-selenium==3.4.3
+selenium==3.141.0
 six==1.12.0
 toml==0.10.0
 tox-battery==0.5.1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,6 +1,6 @@
 jenkinsapi
 pytest
 requests
-bok-choy==0.7.1
+bok-choy
 PyYAML
-selenium==3.4.3
+selenium

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,10 +6,10 @@
 #
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via packaging, pytest
-bok-choy==0.7.1
+bok-choy==1.0.0
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
-configparser==3.8.1       # via importlib-metadata
+configparser==4.0.1       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 funcsigs==1.0.2           # via pytest
 idna==2.8                 # via requests
@@ -17,11 +17,8 @@ importlib-metadata==0.20  # via pluggy, pytest
 jenkinsapi==0.3.9
 lazy==1.4                 # via bok-choy
 more-itertools==5.0.0     # via pytest, zipp
-needle==0.5.0             # via bok-choy
-nose==1.3.7               # via needle
 packaging==19.1           # via pytest
 pathlib2==2.3.4           # via importlib-metadata, pytest
-pillow==6.1.0             # via needle
 pluggy==0.12.0            # via pytest
 py==1.8.0                 # via pytest
 pyparsing==2.4.2          # via packaging
@@ -30,8 +27,8 @@ pytz==2019.2              # via jenkinsapi
 pyyaml==5.1.2
 requests==2.22.0
 scandir==1.10.0           # via pathlib2
-selenium==3.4.3
+selenium==3.141.0
 six==1.12.0               # via bok-choy, jenkinsapi, more-itertools, packaging, pathlib2, pytest
-urllib3==1.25.3           # via requests
+urllib3==1.25.3           # via requests, selenium
 wcwidth==0.1.7            # via pytest
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 attrs==19.1.0             # via packaging
-configparser==3.8.1       # via importlib-metadata
+configparser==4.0.1       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 filelock==3.0.12          # via tox
 importlib-metadata==0.20  # via pluggy, tox

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ passenv =
     DISPLAY
     BOKCHOY_HEADLESS
     MOZ_HEADLESS
+    SCREENSHOT_DIR
     SELENIUM_BROWSER
+    SELENIUM_DRIVER_LOG_DIR
     TEST_SHARD
 commands =
     pytest {posargs}


### PR DESCRIPTION
Some fixes to modernize the tests so they can run faster and be reproduced locally:

* Upgrade Firefox and geckodriver
* Upgrade bok-choy and selenium
* Run the tests in headless mode
* Use a newer Travis CI worker

Had to fix 2 page objects in the process to work with the newer Firefox version.