### PR TITLE
TE-2854 Run modernize, test Python 3.5 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ matrix:
   include:
   - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py27
   - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py27
-  - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py36
-  - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py36
+  - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py35
+    addons:
+      apt:
+        packages: python3-pip
+  - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py35
+    addons:
+      apt:
+        packages: python3-pip
 
 dist: xenial
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
   include:
   - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py27
   - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py27
+  - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py36
+  - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.150.2' TOXENV=py36
 
 dist: xenial
 sudo: required

--- a/e2e/pages/__init__.py
+++ b/e2e/pages/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 JENKINS_HOST = os.getenv('JENKINS_HOST', 'localhost')

--- a/e2e/pages/configuration_page.py
+++ b/e2e/pages/configuration_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from selenium.webdriver.common.action_chains import ActionChains
 
 from . import JENKINS_HOST

--- a/e2e/pages/credential_store_page.py
+++ b/e2e/pages/credential_store_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
 

--- a/e2e/pages/dashboard_page.py
+++ b/e2e/pages/dashboard_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
 

--- a/e2e/pages/ec2_configuration_subpage.py
+++ b/e2e/pages/ec2_configuration_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class Ec2ConfigurationSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/email_ext_subpage.py
+++ b/e2e/pages/email_ext_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class EmailExtConfigurationSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/ghprb_configuration_subpage.py
+++ b/e2e/pages/ghprb_configuration_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class GHPRBConfigurationSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/ghprb_log_configure_page.py
+++ b/e2e/pages/ghprb_log_configure_page.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
+from six.moves import zip
 
 class GhprbLogConfigurePage(PageObject):
 
@@ -14,4 +16,4 @@ class GhprbLogConfigurePage(PageObject):
     def get_loggers_with_level(self):
         logger_names = self.q(css='[class="setting-input  auto-complete  yui-ac-input"]').attrs('value')
         level = self.q(css='[name="level"] > [selected="true"]').text
-        return zip(logger_names, level)
+        return list(zip(logger_names, level))

--- a/e2e/pages/git_configuration_subpage.py
+++ b/e2e/pages/git_configuration_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class GitConfigurationSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/github_configuration_subpage.py
+++ b/e2e/pages/github_configuration_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class GithubConfigurationSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/global_tool_page.py
+++ b/e2e/pages/global_tool_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import re
 from . import JENKINS_HOST

--- a/e2e/pages/hipchat_config_subpage.py
+++ b/e2e/pages/hipchat_config_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class HipChatConfigSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/job_config_history_subpage.py
+++ b/e2e/pages/job_config_history_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class JobConfigHistorySubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/log_recorder_page.py
+++ b/e2e/pages/log_recorder_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
 

--- a/e2e/pages/mailer_subpage.py
+++ b/e2e/pages/mailer_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class MailerConfigurationSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/mask_passwords_configuration_subpage.py
+++ b/e2e/pages/mask_passwords_configuration_subpage.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
+from six.moves import zip
 
 class MaskPasswordsSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/people_page.py
+++ b/e2e/pages/people_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
 

--- a/e2e/pages/security_page.py
+++ b/e2e/pages/security_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import re
 from . import JENKINS_HOST

--- a/e2e/pages/slack_config_subpage.py
+++ b/e2e/pages/slack_config_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class SlackConfigSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/splunk_config_subpage.py
+++ b/e2e/pages/splunk_config_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 class SplunkConfigSubPage(ConfigurationSubPageMixIn, PageObject):
 

--- a/e2e/pages/timestamper_config_subpage.py
+++ b/e2e/pages/timestamper_config_subpage.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from . import JENKINS_HOST
 from bok_choy.page_object import PageObject
-from configuration_page import ConfigurationSubPageMixIn
+from .configuration_page import ConfigurationSubPageMixIn
 
 
 class TimestamperConfigSubPage(ConfigurationSubPageMixIn, PageObject):

--- a/e2e/test_access.py
+++ b/e2e/test_access.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from unittest import TestCase
 
 import requests

--- a/e2e/test_configuration_page.py
+++ b/e2e/test_configuration_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.configuration_page import JenkinsConfigurationPage
+from .pages.configuration_page import JenkinsConfigurationPage
 
 class TestConfiguration(WebAppTest):
     

--- a/e2e/test_credential_store_page.py
+++ b/e2e/test_credential_store_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.credential_store_page import CredentialStorePage
+from .pages.credential_store_page import CredentialStorePage
 
 class TestConfiguration(WebAppTest):
     

--- a/e2e/test_dashboard_page.py
+++ b/e2e/test_dashboard_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.dashboard_page import JenkinsDashboardPage
+from .pages.dashboard_page import JenkinsDashboardPage
 
 class TestDashboard(WebAppTest):
     

--- a/e2e/test_ec2_configuration_page.py
+++ b/e2e/test_ec2_configuration_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.ec2_configuration_subpage import Ec2ConfigurationSubPage
+from .pages.ec2_configuration_subpage import Ec2ConfigurationSubPage
 
 class TestEc2ConfigurationSubPage(WebAppTest):
 

--- a/e2e/test_email_ext_configuration.py
+++ b/e2e/test_email_ext_configuration.py
@@ -1,8 +1,8 @@
-import unittest
+from __future__ import absolute_import
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.email_ext_subpage import EmailExtConfigurationSubPage
+from .pages.email_ext_subpage import EmailExtConfigurationSubPage
 
 class TestEmailExtConfiguration(WebAppTest):
     

--- a/e2e/test_ghprb_log_configure_page.py
+++ b/e2e/test_ghprb_log_configure_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.ghprb_log_configure_page import GhprbLogConfigurePage
+from .pages.ghprb_log_configure_page import GhprbLogConfigurePage
 
 class TestGhprbLogConfigurePage(WebAppTest):
 

--- a/e2e/test_ghprb_plugin_configuration.py
+++ b/e2e/test_ghprb_plugin_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.ghprb_configuration_subpage import GHPRBConfigurationSubPage
+from .pages.ghprb_configuration_subpage import GHPRBConfigurationSubPage
 
 class TestGHPRBConfiguration(WebAppTest):
 

--- a/e2e/test_git_plugin_config.py
+++ b/e2e/test_git_plugin_config.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.git_configuration_subpage import GitConfigurationSubPage
+from .pages.git_configuration_subpage import GitConfigurationSubPage
 
 class TestGitConfiguration(WebAppTest):
     

--- a/e2e/test_github_configuration.py
+++ b/e2e/test_github_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.github_configuration_subpage import GithubConfigurationSubPage
+from .pages.github_configuration_subpage import GithubConfigurationSubPage
 
 class TestGithubConfiguration(WebAppTest):
     

--- a/e2e/test_global_tool_page.py
+++ b/e2e/test_global_tool_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.global_tool_page import GlobalToolConfigurationPage
+from .pages.global_tool_page import GlobalToolConfigurationPage
 
 class TestGlobalToolConfiguration(WebAppTest):
 

--- a/e2e/test_hipchat_plugin_config.py
+++ b/e2e/test_hipchat_plugin_config.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.hipchat_config_subpage import HipChatConfigSubPage
+from .pages.hipchat_config_subpage import HipChatConfigSubPage
 
 class TestHipChatConfig(WebAppTest):
 

--- a/e2e/test_job_config_history.py
+++ b/e2e/test_job_config_history.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.job_config_history_subpage import JobConfigHistorySubPage
+from .pages.job_config_history_subpage import JobConfigHistorySubPage
 
 class TestJobConfigHistory(WebAppTest):
 

--- a/e2e/test_log_recorder_page.py
+++ b/e2e/test_log_recorder_page.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.log_recorder_page import JenkinsLogRecorderPage
+from .pages.log_recorder_page import JenkinsLogRecorderPage
 
 class TestLogRecorderPage(WebAppTest):
 

--- a/e2e/test_mailer_configuration.py
+++ b/e2e/test_mailer_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.mailer_subpage import MailerConfigurationSubPage
+from .pages.mailer_subpage import MailerConfigurationSubPage
 
 class TestMailerConfiguration(WebAppTest):
     

--- a/e2e/test_mask_passwords_configuration.py
+++ b/e2e/test_mask_passwords_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.mask_passwords_configuration_subpage import MaskPasswordsSubPage
+from .pages.mask_passwords_configuration_subpage import MaskPasswordsSubPage
 
 class TestMaskPasswordsConfiguration(WebAppTest):
 

--- a/e2e/test_people_page.py
+++ b/e2e/test_people_page.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
@@ -5,7 +6,7 @@ import os
 import pytest
 
 from bok_choy.web_app_test import WebAppTest
-from pages.people_page import PeoplePage
+from .pages.people_page import PeoplePage
 
 test_shard = os.getenv('TEST_SHARD')
 

--- a/e2e/test_plugin_installations.py
+++ b/e2e/test_plugin_installations.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import, print_function
 from unittest import TestCase
 
+import six
 from jenkinsapi.jenkins import Jenkins
+
 
 class PluginTestCase(TestCase):
 
@@ -10,9 +13,9 @@ class PluginTestCase(TestCase):
 
     def test_sample_plugins_installed(self):
         installed_plugin_versions = {
-                value.shortName: value.version
-                for _, value in self.plugins.iteritems()
-                }
+            value.shortName: value.version
+            for value in self.plugins.values()
+        }
         expected_plugin_versions = {
             # Plugins pinned in test_data/plugins.yml
             "ant": "1.8",
@@ -106,7 +109,7 @@ class PluginTestCase(TestCase):
             "workflow-step-api": "2.16",
             "workflow-support": "2.17"
         }
-        for plugin, version in expected_plugin_versions.iteritems():
-            print "Checking if {} at version {} is installed".format(
-                    plugin, expected_plugin_versions[plugin])
+        for plugin, version in six.iteritems(expected_plugin_versions):
+            print("Checking if {} at version {} is installed".format(
+                    plugin, expected_plugin_versions[plugin]))
             assert installed_plugin_versions[plugin] == version

--- a/e2e/test_security_configuration.py
+++ b/e2e/test_security_configuration.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
@@ -5,7 +6,7 @@ import os
 import pytest
 
 from bok_choy.web_app_test import WebAppTest
-from pages.security_page import SecurityConfigurationPage
+from .pages.security_page import SecurityConfigurationPage
 
 test_shard = os.getenv('TEST_SHARD')
 

--- a/e2e/test_slack_configuration.py
+++ b/e2e/test_slack_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.slack_config_subpage import SlackConfigSubPage
+from .pages.slack_config_subpage import SlackConfigSubPage
 
 class TestSlackConfig(WebAppTest):
 

--- a/e2e/test_splunk_plugin_configuration.py
+++ b/e2e/test_splunk_plugin_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.splunk_config_subpage import SplunkConfigSubPage
+from .pages.splunk_config_subpage import SplunkConfigSubPage
 
 class TestSplunkConfig(WebAppTest):
 

--- a/e2e/test_timestamper_configuration.py
+++ b/e2e/test_timestamper_configuration.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import yaml
 import os
 from bok_choy.web_app_test import WebAppTest
-from pages.timestamper_config_subpage import TimestamperConfigSubPage
+from .pages.timestamper_config_subpage import TimestamperConfigSubPage
 
 
 class TestTimestamperConfig(WebAppTest):


### PR DESCRIPTION
Ran `python-modernize` and enabled tests for Python 3.5 in Travis.  Because we're using the groovy worker instead of python workers, we'd need to add the deadsnakes PPA in order to install and test versions newer than this (but 3.5 is what we'll be using in the short term anyway, until the Ubuntu 18.04 upgrade).