### PR TITLE
stop pinning dependencies that are not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,13 @@ before_install:
 addons:
     firefox: '69.0'
 
+# Skip the "install" step, as it will cause travis to automatically call 'gradle assemble'.
+# We don't want to do this, as it will try to compile the groovy code in `src`, which will
+# cause errors because we are not pinning dependencies in the gradle file. Compilation/assembly
+# is unnecessary, as the code will be run by Jenkins and we are not building artifacts here.
+# see: https://github.com/travis-ci/travis-ci/issues/8667#issuecomment-366589908
+install: skip
+
 script:
     - export CI_SYSTEM='travis'
     - make quality

--- a/build.gradle
+++ b/build.gradle
@@ -19,38 +19,6 @@ configurations {
 
 dependencies {
     libs 'org.apache.ivy:ivy:2.4.0@jar'
-    compile 'org.codehaus.groovy:groovy-all:2.1.3'
-    compile 'javax.servlet:servlet-api:2.4'
-    compile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
-    compile 'org.kohsuke:github-api:1.90'
-    compile 'org.jenkins-ci.plugins:ghprb:1.42.0@jar'
-    compile 'com.coravy.hudson.plugins.github:github:1.29.2@jar'
-    compile 'org.jenkins-ci.plugins:ec2:1.42@jar'
-    compile 'org.jenkins-ci.plugins:email-ext:2.62@jar'
-    compile 'org.jenkins-ci.plugins:matrix-auth:1.5@jar'
-    compile 'org.jenkins-ci.plugins:github-oauth:0.31@jar'
-    compile 'org.jenkins-ci.plugins:aws-credentials:1.24@jar'
-    compile 'org.jenkins-ci.plugins:credentials:2.1.18@jar'
-    compile 'org.jenkins-ci.plugins:plain-credentials:1.4@jar'
-    compile 'org.jenkins-ci.plugins:ssh-credentials:1.14@jar'
-    compile 'org.jenkins-ci.plugins:gradle:1.29@jar'
-    compile 'org.jenkins-ci.plugins:groovy:2.1@jar'
-    compile 'org.jenkins-ci.plugins:shiningpanda:0.23@jar'
-    compile 'org.jenkins-ci.plugins:jobConfigHistory:2.19@jar'
-    compile 'org.jenkins-ci.plugins:job-dsl:1.70'
-    compile 'org.jenkins-ci.plugins:job-dsl:1.70@jar'
-    compile 'org.jenkins-ci.plugins:antisamy-markup-formatter:1.5@jar'
-    compile 'org.kohsuke:owasp-html-sanitizer:r88@jar'
-    compile 'org.jvnet.hudson.plugins:hipchat:0.1.9@jar'
-    compile 'org.jenkins-ci.plugins:mailer:1.21@jar'
-    compile 'org.jenkins-ci.plugins:mask-passwords:2.10.1@jar'
-    compile 'com.amazonaws:aws-java-sdk:1.11.457'
-    compile 'com.splunk.splunkins:splunk-devops:1.6.4@jar'
-    compile 'org.jenkins-ci.plugins:saml:1.1.0@jar'
-    compile 'org.pac4j:pac4j-saml:1.9.9'
-    testCompile 'org.codehaus.groovy:groovy-all:2.1.3'
-    testCompile 'javax.servlet:servlet-api:2.4'
-    testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}"
 }
 
 codenarc {


### PR DESCRIPTION
So it turns out that we never really needed to pin dependencies in the build.grade file, because weren't using them- Travis was! Travis was automatically calling `gradle assemble` which tries to compile the  groovy code in `src`. This code has tons of imports from Jenkins and plugin code, and if you try to compile that without having the dependencies present, it will explode. Skipping the `install` step in Travis will allow us to stop pinning dependencies in the build.gradle file (we pin them in other places for other reasons).