### PR TITLE
bump version of jenkins jpi plugin and gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip

--- a/plugins.gradle
+++ b/plugins.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
   }
   dependencies {
-        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.22.0'
+        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.28.0'
         classpath 'org.yaml:snakeyaml:1.17'
   }
 }
@@ -69,7 +69,7 @@ def parsePluginList() {
     if (pluginConfigKey == null) {
         pluginList = yaml.load(new File(pluginConfig).text)
     } else {
-        Map<String> map = yaml.load(new File(pluginConfig).text)
+        map = yaml.load(new File(pluginConfig).text)
         pluginList = map[pluginConfigKey]
     }
     return pluginList


### PR DESCRIPTION
Bump version of gradle used in this repo to play nicely with newer versions of Java. This requires a bump in the jenkins jpi plugin and a small syntax change.