### PR TITLE
[BD-6] Run tests with python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ before_install:
     - make build
     - make run
     - export BOKCHOY_HEADLESS=true
+    # Install python3.8 interpreter
+    - sudo add-apt-repository ppa:deadsnakes/ppa -y;
+    - sudo apt-get update -y;
+    - sudo apt-get install python3.8 python3.8-distutils python3.8-dev -y;
+
 
 addons:
     firefox: '69.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: groovy
 jdk: openjdk8
 
-matrix:
-  include:
-  - env: TEST_SHARD=shard_1 JENKINS_VERSION='jenkins_2.222.3' TOXENV=py35
-    addons:
-      apt:
-        packages: python3-pip
-  - env: TEST_SHARD=shard_2 JENKINS_VERSION='jenkins_2.222.3' TOXENV=py35
-    addons:
-      apt:
-        packages: python3-pip
+env:
+  global:
+    - JENKINS_VERSION='jenkins_2.222.3'
+  jobs:
+    - TEST_SHARD=shard_1 TOXENV=py35
+    - TEST_SHARD=shard_2 TOXENV=py35
+    - TEST_SHARD=shard_1 TOXENV=py38
+    - TEST_SHARD=shard_2 TOXENV=py38
+      
+addons:
+  apt:
+    packages: python3-pip
 
 dist: xenial
 sudo: required

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36}
+envlist = {py35,py38}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Add python3.8 toxenv, and run tests in python3.8

Install python3.8 interpreter in travis worker.

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179