### PR TITLE
BOM-2247: Upgrade pip-tools

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,6 @@ futures ; python_version == "2.7"
 # A dependency of pytest.  Pytest doesn't constrain it and 6.0.0 onward
 # only works with python 3
 more-itertools<6.0.0
+
+# See https://openedx.atlassian.net/browse/BOM-2247 for details.
+pip-tools==5.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ selenium==3.141.0         # via -r requirements/test.txt, bok-choy
 singledispatch==3.6.1     # via -r requirements/travis.txt, importlib-resources
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, bok-choy, jenkinsapi, more-itertools, pathlib2, pip-tools, pytest, singledispatch, tox, virtualenv
 toml==0.10.2              # via -r requirements/travis.txt, tox
-tox-battery==0.6.1        # via -r requirements/travis.txt
+tox-battery==0.5.1        # via -r requirements/travis.txt
 tox==3.23.0               # via -r requirements/travis.txt, tox-battery
 typing==3.7.4.3           # via -r requirements/travis.txt, importlib-resources
 urllib3==1.26.4           # via -r requirements/test.txt, requests, selenium

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,38 +4,47 @@
 #
 #    make upgrade
 #
-atomicwrites==1.3.0
-attrs==19.3.0
-bok-choy==1.0.0
-certifi==2019.9.11
-chardet==3.0.4
-click==7.0
-configparser==4.0.2
-contextlib2==0.6.0.post1
-filelock==3.0.12
-funcsigs==1.0.2
-idna==2.8
-importlib-metadata==0.23
-jenkinsapi==0.3.10
-lazy==1.4
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pip-tools==4.2.0
-pluggy==0.13.0
-py==1.8.0
-pyparsing==2.4.2
-pytest==4.6.6
-pytz==2019.3
-pyyaml==5.1.2
-requests==2.22.0
-scandir==1.10.0
-selenium==3.141.0
-six==1.12.0
-toml==0.10.0
-tox-battery==0.5.1
-tox==3.14.0
-urllib3==1.25.6
-virtualenv==16.7.7
-wcwidth==0.1.7
-zipp==0.6.0
+appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
+atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
+attrs==20.3.0             # via -r requirements/test.txt, pytest
+backports.functools-lru-cache==1.6.4  # via -r requirements/test.txt, wcwidth
+bok-choy==1.1.1           # via -r requirements/test.txt
+certifi==2020.12.5        # via -r requirements/test.txt, requests
+chardet==4.0.0            # via -r requirements/test.txt, requests
+click==7.1.2              # via -r requirements/pip-tools.txt, pip-tools
+configparser==4.0.2       # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata
+contextlib2==0.6.0.post1  # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, zipp
+distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
+filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+funcsigs==1.0.2           # via -r requirements/test.txt, pytest
+idna==2.10                # via -r requirements/test.txt, requests
+importlib-metadata==2.1.1  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via -r requirements/travis.txt, virtualenv
+jenkinsapi==0.3.11        # via -r requirements/test.txt
+lazy==1.4                 # via -r requirements/test.txt, bok-choy
+more-itertools==5.0.0     # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
+packaging==20.9           # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
+pathlib2==2.3.5           # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, pytest, virtualenv
+pip-tools==5.3.0          # via -c requirements/constraints.txt, -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
+py==1.10.0                # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
+pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
+pytest==4.6.11            # via -r requirements/test.txt
+pytz==2021.1              # via -r requirements/test.txt, jenkinsapi
+pyyaml==5.4.1             # via -r requirements/test.txt
+requests==2.25.1          # via -r requirements/test.txt, jenkinsapi
+scandir==1.10.0           # via -r requirements/test.txt, -r requirements/travis.txt, pathlib2
+selenium==3.141.0         # via -r requirements/test.txt, bok-choy
+singledispatch==3.6.1     # via -r requirements/travis.txt, importlib-resources
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, bok-choy, jenkinsapi, more-itertools, pathlib2, pip-tools, pytest, singledispatch, tox, virtualenv
+toml==0.10.2              # via -r requirements/travis.txt, tox
+tox-battery==0.6.1        # via -r requirements/travis.txt
+tox==3.23.0               # via -r requirements/travis.txt, tox-battery
+typing==3.7.4.3           # via -r requirements/travis.txt, importlib-resources
+urllib3==1.26.4           # via -r requirements/test.txt, requests, selenium
+virtualenv==20.4.4        # via -r requirements/travis.txt, tox
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
+zipp==1.2.0               # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.2.0
-six==1.12.0               # via pip-tools
+click==7.1.2              # via pip-tools
+pip-tools==5.3.0          # via -c requirements/constraints.txt, -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,31 +4,32 @@
 #
 #    make upgrade
 #
-atomicwrites==1.3.0       # via pytest
-attrs==19.3.0             # via pytest
-bok-choy==1.0.0
-certifi==2019.9.11        # via requests
-chardet==3.0.4            # via requests
+atomicwrites==1.4.0       # via pytest
+attrs==20.3.0             # via pytest
+backports.functools-lru-cache==1.6.4  # via wcwidth
+bok-choy==1.1.1           # via -r requirements/test.in
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata
 funcsigs==1.0.2           # via pytest
-idna==2.8                 # via requests
-importlib-metadata==0.23  # via pluggy, pytest
-jenkinsapi==0.3.10
+idna==2.10                # via requests
+importlib-metadata==2.1.1  # via pluggy, pytest
+jenkinsapi==0.3.11        # via -r requirements/test.in
 lazy==1.4                 # via bok-choy
-more-itertools==5.0.0     # via pytest, zipp
-packaging==19.2           # via pytest
+more-itertools==5.0.0     # via pytest
+packaging==20.9           # via pytest
 pathlib2==2.3.5           # via importlib-metadata, pytest
-pluggy==0.13.0            # via pytest
-py==1.8.0                 # via pytest
-pyparsing==2.4.2          # via packaging
-pytest==4.6.6
-pytz==2019.3              # via jenkinsapi
-pyyaml==5.1.2
-requests==2.22.0
+pluggy==0.13.1            # via pytest
+py==1.10.0                # via pytest
+pyparsing==2.4.7          # via packaging
+pytest==4.6.11            # via -r requirements/test.in
+pytz==2021.1              # via jenkinsapi
+pyyaml==5.4.1             # via -r requirements/test.in
+requests==2.25.1          # via -r requirements/test.in, jenkinsapi
 scandir==1.10.0           # via pathlib2
-selenium==3.141.0
-six==1.12.0               # via bok-choy, jenkinsapi, more-itertools, packaging, pathlib2, pytest
-urllib3==1.25.6           # via requests, selenium
-wcwidth==0.1.7            # via pytest
-zipp==0.6.0               # via importlib-metadata
+selenium==3.141.0         # via -r requirements/test.in, bok-choy
+six==1.15.0               # via bok-choy, jenkinsapi, more-itertools, pathlib2, pytest
+urllib3==1.26.4           # via requests, selenium
+wcwidth==0.2.5            # via pytest
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -20,7 +20,7 @@ scandir==1.10.0           # via pathlib2
 singledispatch==3.6.1     # via importlib-resources
 six==1.15.0               # via pathlib2, tox, virtualenv
 toml==0.10.2              # via tox
-tox-battery==0.6.1        # via -r requirements/travis.in
+tox-battery==0.5.1        # via -r requirements/travis.in
 tox==3.23.0               # via -r requirements/travis.in, tox-battery
 typing==3.7.4.3           # via importlib-resources
 virtualenv==20.4.4        # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,20 +4,24 @@
 #
 #    make upgrade
 #
+appdirs==1.4.4            # via virtualenv
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
-filelock==3.0.12          # via tox
-importlib-metadata==0.23  # via pluggy, tox
-more-itertools==5.0.0     # via zipp
-packaging==19.2           # via tox
-pathlib2==2.3.5           # via importlib-metadata
-pluggy==0.13.0            # via tox
-py==1.8.0                 # via tox
-pyparsing==2.4.2          # via packaging
+contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
+distlib==0.3.1            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
+importlib-resources==3.3.1  # via virtualenv
+packaging==20.9           # via tox
+pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
+pluggy==0.13.1            # via tox
+py==1.10.0                # via tox
+pyparsing==2.4.7          # via packaging
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via packaging, pathlib2, tox
-toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.0
-virtualenv==16.7.7        # via tox
-zipp==0.6.0               # via importlib-metadata
+singledispatch==3.6.1     # via importlib-resources
+six==1.15.0               # via pathlib2, tox, virtualenv
+toml==0.10.2              # via tox
+tox-battery==0.6.1        # via -r requirements/travis.in
+tox==3.23.0               # via -r requirements/travis.in, tox-battery
+typing==3.7.4.3           # via importlib-resources
+virtualenv==20.4.4        # via tox
+zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
We are using `pip==20.0.2` in configuration, which is compatible with pip-tools up to version `5.3.0`.
The compatibility chart is available at https://github.com/jazzband/pip-tools/#versions-and-compatibility

See https://openedx.atlassian.net/browse/BOM-2247 for details.