### PR TITLE
fix: update the resource path for the gradle-jpi-plugin

### DIFF
--- a/plugins.gradle
+++ b/plugins.gradle
@@ -5,11 +5,11 @@ buildscript {
   repositories {
         mavenCentral()
         maven {
-          url 'http://repo.jenkins-ci.org/releases/'
+          url "https://plugins.gradle.org/m2/"
         }
   }
   dependencies {
-        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.28.0'
+        classpath "gradle.plugin.org.jenkins-ci.tools:gradle-jpi-plugin:0.28.0"
         classpath 'org.yaml:snakeyaml:1.17'
   }
 }


### PR DESCRIPTION
The `plugins` make target has started failing with the following error message:
```
Caused by: org.gradle.api.plugins.UnknownPluginException: Plugin with id 'org.jenkins-ci.jpi' not found.
```
It looks like the plugin in question is being hosted at a different URL. Here is an example of how to configure your build.gradle file to download it: https://plugins.gradle.org/plugin/org.jenkins-ci.jpi/0.28.0