### PR TITLE
Add groovy script to start Jenkins in maintenance mode

### DIFF
--- a/src/main/groovy/9StartInQuietMode.groovy
+++ b/src/main/groovy/9StartInQuietMode.groovy
@@ -1,0 +1,5 @@
+import jenkins.model.Jenkins;
+
+// start in the state that doesn't do any build.
+Jenkins.instance.doQuietDown();
+


### PR DESCRIPTION
This PR adds a Groovy init script to force Jenkins to start in maintenance. The script in question is used in the Jenkins ansible playbooks owned by Data Engineering to force Jenkins to start in maintenance mode. This is related to [openedx/configuration PR 6796](https://github.com/openedx/configuration/pull/6796).